### PR TITLE
Add material on contributing to nimbella-cli

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,30 +22,20 @@ All such contributions should be in the form of pull requests.  The exact format
 
 - _motivation_: what problem the contribution is trying to solve and why it should be regarded as helpful
 - _externals_: what visible changes to the behavior of `nim` will occur if the pull request is merged
-- _internals_: (if a reading of the code is likely to raise questions) anything that will help orient a reviewer to reading the code.
+- (optionally) _internals_: anything that will help orient a reviewer in reading the code.
 
 By opening a pull request
 
 - You agree that your contributions will be licensed under the [Apache 2.0 License](LICENSE).
 - When you open a pull request with your contributions, **you are certifying that you wrote the code** in the corresponding patch pursuant to the [Developer Certificate of Origin](#developer-certificate-of-origin) included below for your reference.
 - You must conform to our style guidelines.  Issue `npm run lint` and fix any errors or warnings before submitting.
-- If you're contributing a new `nim` subcommand, you must follow the [guide below](#creating-a-new-subcommand).
+- If you're contributing a new `nim` subcommand, please read [our command authoring guide](commandAuthoringGuide.md) and follow its guidance.
 
 ---
 
 ### Contact us.
 
 We're always happy to help you with any issues you encounter. You may want to [join our Slack community](https://nimbella-community.slack.com/) to engage with us for a more rapid response.
-
----
-
-### Creating a new `nim` subcommand
-
-The Nimbella CLI is built on the [oclif framework](https://oclif.io/docs/commands).  But, `nim` adds a layer to `oclif` to facilitate embedding `nim` subcommands in browser-based environments such as our workbench.  Having familiarized yourself with writing `oclif` commands, consider the following additional rules.
-
-1.  By convention, the "topic" tree in `nim` has limited depth.  You can have a command called `nim shop meat` but not `nim shop groceries meat`.
-2. Every topic (like `shop` in the above example) _must_ be listed in `oclif.topics` in `package.json`.  This is optional for `oclif` but required for `nim`.
-3. All `nim` commands must inherit from 
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ This document outlines the process for contributing to `nim`. It also provides s
 The easiest way to contribute is to open an issue with a bug report or a suggestion for improvement.   We do not have a prescriptive issue template.  We merely request that you take the time to communicate clearly so that we can understand what is being requested and respond appropriately.
 
 - For bug reports, give as much detail as you can about exactly what you were doing when the problem occurred and use transcripts or screen shots to show the problematic behavior.
-- For enhancement requests, give the context.  Ideally, explain why the Nimbella community would be interested in the improvement.  Then, be as explicit as you can about how you see the change working, down to a proposed syntax.
+- For enhancement requests, give the context.  Ideally, explain why the Nimbella community would be interested in the improvement.  Then, be as explicit as you can about how you see the change looking and behaving.
 - Check other open issues and add comments to existing issues rather than creating duplicates.
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,92 @@
+## Contributing to the Nimbella CLI
+
+This document outlines the process for contributing to `nim`. It also provides some specific guidance for code contributions.
+
+- We have a [Code of Conduct](CODE_OF_CONDUCT.md), please review it so you are familiar with the project values.
+
+---
+
+### Issues
+
+The easiest way to contribute is to open an issue with a bug report or a suggestion for improvement.   We do not have a prescriptive issue template.  We merely request that you take the time to communicate clearly so that we can understand what is being requested and respond appropriately.
+
+- For bug reports, give as much detail as you can about exactly what you were doing when the problem occurred and use transcripts or screen shots to show the problematic behavior.
+- For enhancement requests, give the context.  Ideally, explain why the Nimbella community would be interested in the improvement.  Then, be as explicit as you can about how you see the change working, down to a proposed syntax.
+- Check other open issues and add comments to existing issues rather than creating duplicates.
+
+---
+
+### Contributions of source code
+
+All such contributions should be in the form of pull requests.  The exact format of the pull request description is not important but it should include
+
+- _motivation_: what problem the contribution is trying to solve and why it should be regarded as helpful
+- _externals_: what visible changes to the behavior of `nim` will occur if the pull request is merged
+- _internals_: (if a reading of the code is likely to raise questions) anything that will help orient a reviewer to reading the code.
+
+By opening a pull request
+
+- You agree that your contributions will be licensed under the [Apache 2.0 License](LICENSE).
+- When you open a pull request with your contributions, **you are certifying that you wrote the code** in the corresponding patch pursuant to the [Developer Certificate of Origin](#developer-certificate-of-origin) included below for your reference.
+- You must conform to our style guidelines.  Issue `npm run lint` and fix any errors or warnings before submitting.
+- If you're contributing a new `nim` subcommand, you must follow the [guide below](#creating-a-new-subcommand).
+
+---
+
+### Contact us.
+
+We're always happy to help you with any issues you encounter. You may want to [join our Slack community](https://nimbella-community.slack.com/) to engage with us for a more rapid response.
+
+---
+
+### Creating a new `nim` subcommand
+
+The Nimbella CLI is built on the [oclif framework](https://oclif.io/docs/commands).  But, `nim` adds a layer to `oclif` to facilitate embedding `nim` subcommands in browser-based environments such as our workbench.  Having familiarized yourself with writing `oclif` commands, consider the following additional rules.
+
+1.  By convention, the "topic" tree in `nim` has limited depth.  You can have a command called `nim shop meat` but not `nim shop groceries meat`.
+2. Every topic (like `shop` in the above example) _must_ be listed in `oclif.topics` in `package.json`.  This is optional for `oclif` but required for `nim`.
+3. All `nim` commands must inherit from 
+
+---
+
+### Developer Certificate of Origin
+
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```

--- a/commandAuthoringGuide.md
+++ b/commandAuthoringGuide.md
@@ -4,6 +4,8 @@ The Nimbella CLI is built on the [oclif framework](https://oclif.io/docs/introdu
 
 The Nimbella CLI includes the [plugins plugin](https://github.com/oclif/plugin-plugins).  So, you have a choice.  You can package additional subcommands in a plugin, or you can submit a PR to modify `nim` itself.  The choice should depend on the general applicability of the subcommand.  If the potential usage community for your new command is narrow, consider using a plugin.
 
+Regardless of which you choose, we expect all contributions to conform to our [code of conduct](CODE_OF_CONDUCT.md).
+
 If you do use a plugin,
 
 - you will need to publish it to an `npm` repository or disseminate github coordinates

--- a/commandAuthoringGuide.md
+++ b/commandAuthoringGuide.md
@@ -9,6 +9,7 @@ Regardless of which you choose, we expect all contributions to conform to our [c
 If you do use a plugin,
 
 - you will need to publish it to an `npm` repository or disseminate github coordinates
+- you should choose a name for the plugin that starts with `nim-plugin-`
 - `nim` users will be able to install it with
 
 ```
@@ -19,10 +20,10 @@ nim plugin install <your-plugin>
 
 If your command is broadly applicable, consider submitting a PR to add the command directly to `nim`.  
 
-- If we accept the submission, Nimbella will then take responsibility for servicing users of the command
-- If appropriate (no local file system access) the subcommand may run in the Nimbella workbench
-- But, in this case the additional guidelines shown below must be followed.
+- The additional guidelines shown below must be followed.
 - Look at the source of an existing subcommand for examples of correct usage.
+- If we accept the submission, Nimbella will then take responsibility for servicing users of the command
+- If appropriate (no local file system access) we may choose to provide subcommand in the Nimbella workbench
 
 ---
 
@@ -74,6 +75,9 @@ The first two of these duplicate methods provided by `oclif`'s `Command` and sho
 
 - you can use `chalk` sparingly for decoration and contrast
 - Do not directly use `cli-ux`: it breaks the Nimbella workbench
-- The supplied utilities in [ui.ts](https://github.com/nimbella/nimbella-cli/blob/master/src/ui.ts) abstract some common user interactions such as prompting and spinners.  These may use `cli-ux` internally but demand-load it to ensure it is not used in the workbench.
+- The supplied utilities in [ui.ts](https://github.com/nimbella/nimbella-cli/blob/master/src/ui.ts) abstract some common user interactions such as prompting and spinners.
+   - always use these utilities in preference to alternatives when you can
+   - if you have a user interaction need that isn't covered by `ui.ts` then add that interaction to `ui.ts` as part of your PR and we will review it accordingly
+	- note that `ui.ts` uses `cli-ux` internally but demand-loads it when safe and provide alternatives when running in a web browser.  
 
 

--- a/commandAuthoringGuide.md
+++ b/commandAuthoringGuide.md
@@ -1,16 +1,32 @@
 ### Creating a new `nim` subcommand
 
-The Nimbella CLI is built on the [oclif framework](https://oclif.io).  Familiarity with that framework is helpful in understanding the following but is not a substitute for the following.
+The Nimbella CLI is built on the [oclif framework](https://oclif.io/docs/introduction.html).  Some familiarity with that framework helps in understanding the following.
 
-The Nimbella CLI includes the [plugins plugin](https://oclif.io/doc/plugins).  Before adding a command to `nim`, consider whether the constituency for the command is narrow enough that it might better be provided in the form of a plugin.  By publishing the plugin to an `npm` repository, `nim` users will be able to install it with
+The Nimbella CLI includes the [plugins plugin](https://github.com/oclif/plugin-plugins).  So, you have a choice.  You can package additional subcommands in a plugin, or you can submit a PR to modify `nim` itself.  The choice should depend on the general applicability of the subcommand.  If the potential usage community for your new command is narrow, consider using a plugin.
+
+If you do use a plugin,
+
+- you will need to publish it to an `npm` repository or disseminate github coordinates
+- `nim` users will be able to install it with
 
 ```
 nim plugin install <your-plugin>
 ```
 
-If you do submit a PR to add a command directly to `nim`, the following guidelines must be followed.   Look at the source of an existing command for examples of correct usage.  
+- it will be your responsibility to service users of your plugin.  Nimbella will not be able to diagnose problems with it.
 
-**(1)** We support subcommands at top level and commands under one level of topic.  We do not support more deeply nested topics.  You can have a command called 
+If your command is broadly applicable, consider submitting a PR to add the command directly to `nim`.  
+
+- If we accept the submission, Nimbella will then take responsibility for servicing users of the command
+- If appropriate (no local file system access) the subcommand may run in the Nimbella workbench
+- But, in this case the additional guidelines shown below must be followed.
+- Look at the source of an existing subcommand for examples of correct usage.
+
+---
+
+Our guidelines for adding subcommands directly to `nim` are _in addition_ to oclif procedures.  Where they appear to conflict, our guidelines take precedence.
+
+**(1)** We support subcommands at top level and under one level of topic.  We do not support more deeply nested topics.  You can have a command called 
 
 ```
 nim buy
@@ -30,11 +46,11 @@ nim shopping groceries buy
 
 **(2)** Every topic (like `shopping` in the above example) _must_ be listed in `oclif.topics` in `package.json`.
 
-**(3)** All `nim` subcommands must inherit from `NimBaseCommand`.
+**(3)** All `nim` subcommands must inherit from [NimBaseCommand](https://github.com/nimbella/nimbella-cli/blob/dd0396b30b47b419717055871f0955c77ad0d833/deployer/src/NimBaseCommand.ts).
 
-**(4)** `NimBaseCommand` contains a standard implementation of the usual oclif `run` function.  Do not override that function.  Instead, implement `runCommand`.  A description of the arguments passed to that function can be found in `NimBaseCommand.ts`.
+**(4)** `NimBaseCommand` contains a standard implementation of the usual oclif `run` function.  Do not override that function.  Instead, implement `runCommand`.  A description of the arguments passed to that function can be found in [NimBaseCommand.ts](https://github.com/nimbella/nimbella-cli/blob/dd0396b30b47b419717055871f0955c77ad0d833/deployer/src/NimBaseCommand.ts#L112).
 
-**(5)** Do not call methods of `oclif`'s `Command` class via `this` if they write to the console or may terminate execution.  Instead, use the `logger` argument that is passed to `runCommand`.   It conforms to the type `NimLogger` and has the methods
+**(5)** Do not call methods of `oclif`'s `Command` class via `this` if they write to the console or may terminate execution.  Instead, use the `logger` argument that is passed to `runCommand`.   It conforms to the type [NimLogger](https://github.com/nimbella/nimbella-cli/blob/dd0396b30b47b419717055871f0955c77ad0d833/deployer/src/NimBaseCommand.ts#L53) and has the methods
 
 ```
 log
@@ -43,14 +59,19 @@ handleError
 displayError
 ```
 
-(see `NimBaseCommand.ts`).   The first two of these duplicate methods provided by `oclif`'s `Command` and should always be preferred.
+The first two of these duplicate methods provided by `oclif`'s `Command` and should always be preferred.
 
-**(6)** As much as possible, handle errors using `logger.handleError`.  This method was adopted from Adobe's `aio` and provides greater uniformity in error handling than can be achieved using `oclif` alone.
+**(6)** As much as possible, handle errors using [logger.handleError](https://github.com/nimbella/nimbella-cli/blob/dd0396b30b47b419717055871f0955c77ad0d833/deployer/src/NimBaseCommand.ts#L241).  This method was adopted from Adobe's `aio` and imposes some uniformity on error handling that users can then rely on.
 
-**(7)** Don't use `console.log` at all and avoid introducing new dependencies for CLI-based interaction.  Rather
+**(7)** Don't use `console.log` at all.
 
 - for normal execution output use `logger.log`
 - for debugging use `debug`
-- if you need CLI "art" you can use `chalk` but sparingly.  Do not directly use `cli-ux`.  The source `ui.ts` provides some utilities for safely interacting with the user (e.g. prompting)
+
+**(8)** Take care with interaction and CLI "art"
+
+- you can use `chalk` sparingly for decoration and contrast
+- Do not directly use `cli-ux`: it breaks the Nimbella workbench
+- The supplied utilities in [ui.ts](https://github.com/nimbella/nimbella-cli/blob/master/src/ui.ts) abstract some common user interactions such as prompting and spinners.  These may use `cli-ux` internally but demand-load it to ensure it is not used in the workbench.
 
 

--- a/commandAuthoringGuide.md
+++ b/commandAuthoringGuide.md
@@ -1,0 +1,56 @@
+### Creating a new `nim` subcommand
+
+The Nimbella CLI is built on the [oclif framework](https://oclif.io).  Familiarity with that framework is helpful in understanding the following but is not a substitute for the following.
+
+The Nimbella CLI includes the [plugins plugin](https://oclif.io/doc/plugins).  Before adding a command to `nim`, consider whether the constituency for the command is narrow enough that it might better be provided in the form of a plugin.  By publishing the plugin to an `npm` repository, `nim` users will be able to install it with
+
+```
+nim plugin install <your-plugin>
+```
+
+If you do submit a PR to add a command directly to `nim`, the following guidelines must be followed.   Look at the source of an existing command for examples of correct usage.  
+
+**(1)** We support subcommands at top level and commands under one level of topic.  We do not support more deeply nested topics.  You can have a command called 
+
+```
+nim buy
+```
+
+or
+
+```
+nim shopping buy
+```
+
+but not 
+
+```
+nim shopping groceries buy
+```
+
+**(2)** Every topic (like `shopping` in the above example) _must_ be listed in `oclif.topics` in `package.json`.
+
+**(3)** All `nim` subcommands must inherit from `NimBaseCommand`.
+
+**(4)** `NimBaseCommand` contains a standard implementation of the usual oclif `run` function.  Do not override that function.  Instead, implement `runCommand`.  A description of the arguments passed to that function can be found in `NimBaseCommand.ts`.
+
+**(5)** Do not call methods of `oclif`'s `Command` class via `this` if they write to the console or may terminate execution.  Instead, use the `logger` argument that is passed to `runCommand`.   It conforms to the type `NimLogger` and has the methods
+
+```
+log
+exit
+handleError
+displayError
+```
+
+(see `NimBaseCommand.ts`).   The first two of these duplicate methods provided by `oclif`'s `Command` and should always be preferred.
+
+**(6)** As much as possible, handle errors using `logger.handleError`.  This method was adopted from Adobe's `aio` and provides greater uniformity in error handling than can be achieved using `oclif` alone.
+
+**(7)** Don't use `console.log` at all and avoid introducing new dependencies for CLI-based interaction.  Rather
+
+- for normal execution output use `logger.log`
+- for debugging use `debug`
+- if you need CLI "art" you can use `chalk` but sparingly.  Do not directly use `cli-ux`.  The source `ui.ts` provides some utilities for safely interacting with the user (e.g. prompting)
+
+


### PR DESCRIPTION
Adding a more general document (`CONTRIBUTING.md`) as per convention.   This references our lint rules and also a more specific document on authoring `nim` subcommands.   As is done elsewhere, the Developer Certificate of Origin is inline and agreeing to it is implicit in submitting any PR.