### PR TITLE
bump oclif/plugin-plugins version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-autocomplete": "^0.1.5",
-    "@oclif/plugin-plugins": "1.7.9",
+    "@oclif/plugin-plugins": "^1.9.0",
     "@oclif/plugin-update": "^1.3.9",
     "@octokit/rest": "16.36.0",
     "archiver": "^3.0.0",


### PR DESCRIPTION
The **oclif/plugin-plugins** dependency was pegged at **1.7.9**, it was dependent on **oclif/colors** **0.0.0**, which in turn had an unstated dependency on  "chalk": "^2.4.2".
Adding  **"chalk": "^4.1.0"**, as a host dependency led to this error. 
It's been resolved in updated versions  "@oclif/plugin-plugins": "^1.9.0"