### PR TITLE
Do not escape encoded wrapped text.

### DIFF
--- a/deployer/src/deploy.ts
+++ b/deployer/src/deploy.ts
@@ -189,7 +189,7 @@ export async function actionWrap(res: WebResource, reader: ProjectReader): Promi
   const name = res.simpleName.endsWith('.html') ? res.simpleName.replace('.html', '') : res.simpleName
   let bodyExpr = `  const body = '${body}'`
   if (isTextType(res.mimeType)) {
-    bodyExpr = "  const body = `${Buffer.from('" + body + "', 'base64').toString('utf-8').split('\\\\').join('\\\\\\\\').split('`').join('\\\\`')}`"
+    bodyExpr = "  const body = Buffer.from('" + body + "', 'base64').toString('utf-8')"
   }
   let code = `function main() {
     ${bodyExpr}


### PR DESCRIPTION
Since the content is entirely opaque post b64 encoding, do not escape any characters when decoding. The JSON serialization and deserialization will handle.