### PR TITLE
Update to version 3.0 of aio-cli-plugin-runtime

### DIFF
--- a/deployer/src/NimBaseCommand.ts
+++ b/deployer/src/NimBaseCommand.ts
@@ -126,7 +126,7 @@ class AioCommand extends Command {
   logJSON(_hdr: string, _entity: Record<string, unknown>) { /* no-op */ }
   table(data: Record<string, unknown>[], _columns: Record<string, unknown>, _options: Record<string, unknown> = {}) { /* no-op */ }
   async run(_argv?: string[]) { /* no-op */ }
-  static omitWildcardNamespaceHeader: boolean
+  setNamespaceHeaderOmission(newValue: boolean) { /* no-op */ }
 }
 
 // The base for all our commands, including the ones that delegate to aio.  There are methods designed to be called from the
@@ -189,7 +189,6 @@ export abstract class NimBaseCommand extends Command implements NimLogger {
   async runAio(rawArgv: string[], argv: string[], args: any, flags: any, logger: NimLogger, AioClass: typeof AioCommand): Promise<void> {
     debug('runAio with rawArgv: %O, argv: %O, args: %O, flags: %O', rawArgv, argv, args, flags)
     fixAioCredentials(logger, flags)
-    AioClass.omitWildcardNamespaceHeader = true
     const cmd = new AioClass(rawArgv, {} as IConfig)
     if (flags.verbose) {
       debug('verbose flag intercepted')
@@ -206,6 +205,7 @@ export abstract class NimBaseCommand extends Command implements NimLogger {
       cmd.table = this.saveTable(logger)
       logger.command = this.command
       debug('aio capture intercepts installed')
+      cmd.setNamespaceHeaderOmission(true)
       await cmd.run()
     } else {
       cmd.handleError = this.handleError.bind(cmd)

--- a/deployer/src/NimBaseCommand.ts
+++ b/deployer/src/NimBaseCommand.ts
@@ -205,7 +205,11 @@ export abstract class NimBaseCommand extends Command implements NimLogger {
       cmd.table = this.saveTable(logger)
       logger.command = this.command
       debug('aio capture intercepts installed')
-      cmd.setNamespaceHeaderOmission(true)
+      let omitNamespace = true
+      if (this.command.length === 2 && this.command[0].startsWith('activation') && this.command[1] === 'logs') {
+        omitNamespace = false
+      }
+      cmd.setNamespaceHeaderOmission(omitNamespace)
       await cmd.run()
     } else {
       cmd.handleError = this.handleError.bind(cmd)

--- a/deployer/src/NimBaseCommand.ts
+++ b/deployer/src/NimBaseCommand.ts
@@ -205,11 +205,7 @@ export abstract class NimBaseCommand extends Command implements NimLogger {
       cmd.table = this.saveTable(logger)
       logger.command = this.command
       debug('aio capture intercepts installed')
-      let omitNamespace = true
-      if (this.command.length === 2 && this.command[0].startsWith('activation') && this.command[1] === 'logs') {
-        omitNamespace = false
-      }
-      cmd.setNamespaceHeaderOmission(omitNamespace)
+      cmd.setNamespaceHeaderOmission(true)
       await cmd.run()
     } else {
       cmd.handleError = this.handleError.bind(cmd)

--- a/deployer/src/NimBaseCommand.ts
+++ b/deployer/src/NimBaseCommand.ts
@@ -126,6 +126,7 @@ class AioCommand extends Command {
   logJSON(_hdr: string, _entity: Record<string, unknown>) { /* no-op */ }
   table(data: Record<string, unknown>[], _columns: Record<string, unknown>, _options: Record<string, unknown> = {}) { /* no-op */ }
   async run(_argv?: string[]) { /* no-op */ }
+  static omitWildcardNamespaceHeader: boolean
 }
 
 // The base for all our commands, including the ones that delegate to aio.  There are methods designed to be called from the
@@ -188,6 +189,7 @@ export abstract class NimBaseCommand extends Command implements NimLogger {
   async runAio(rawArgv: string[], argv: string[], args: any, flags: any, logger: NimLogger, AioClass: typeof AioCommand): Promise<void> {
     debug('runAio with rawArgv: %O, argv: %O, args: %O, flags: %O', rawArgv, argv, args, flags)
     fixAioCredentials(logger, flags)
+    AioClass.omitWildcardNamespaceHeader = true
     const cmd = new AioClass(rawArgv, {} as IConfig)
     if (flags.verbose) {
       debug('verbose flag intercepted')

--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
   "author": "Nimbella Corporation",
   "license": "Apache-2.0",
   "dependencies": {
-    "@adobe/aio-cli-plugin-runtime": "nimbella/aio-cli-plugin-runtime#v2020-11-26-1",
+    "@adobe/aio-cli-plugin-runtime": "nimbella/aio-cli-plugin-runtime#v2020-12-01-1",
     "@adobe/aio-lib-core-config": "^1.0.15",
+    "@adobe/aio-lib-runtime": "^1.2.1",
     "@google-cloud/storage": "5.3.0",
     "@oclif/command": "^1",
     "@oclif/config": "^1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "author": "Nimbella Corporation",
   "license": "Apache-2.0",
   "dependencies": {
-    "@adobe/aio-cli-plugin-runtime": "nimbella/aio-cli-plugin-runtime#v2020-12-08-1",
+    "@adobe/aio-cli-plugin-runtime": "nimbella/aio-cli-plugin-runtime#v2020-12-09-1",
     "@adobe/aio-lib-core-config": "^1.0.15",
     "@adobe/aio-lib-runtime": "^1.2.1",
     "@google-cloud/storage": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "author": "Nimbella Corporation",
   "license": "Apache-2.0",
   "dependencies": {
-    "@adobe/aio-cli-plugin-runtime": "nimbella/aio-cli-plugin-runtime#v2020-12-07-3",
+    "@adobe/aio-cli-plugin-runtime": "nimbella/aio-cli-plugin-runtime#v2020-12-08-1",
     "@adobe/aio-lib-core-config": "^1.0.15",
     "@adobe/aio-lib-runtime": "^1.2.1",
     "@google-cloud/storage": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "author": "Nimbella Corporation",
   "license": "Apache-2.0",
   "dependencies": {
-    "@adobe/aio-cli-plugin-runtime": "nimbella/aio-cli-plugin-runtime#v2020-12-07-1",
+    "@adobe/aio-cli-plugin-runtime": "nimbella/aio-cli-plugin-runtime#v2020-12-07-2",
     "@adobe/aio-lib-core-config": "^1.0.15",
     "@adobe/aio-lib-runtime": "^1.2.1",
     "@google-cloud/storage": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "author": "Nimbella Corporation",
   "license": "Apache-2.0",
   "dependencies": {
-    "@adobe/aio-cli-plugin-runtime": "nimbella/aio-cli-plugin-runtime#v2020-12-03-1",
+    "@adobe/aio-cli-plugin-runtime": "nimbella/aio-cli-plugin-runtime#v2020-12-07-1",
     "@adobe/aio-lib-core-config": "^1.0.15",
     "@adobe/aio-lib-runtime": "^1.2.1",
     "@google-cloud/storage": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "author": "Nimbella Corporation",
   "license": "Apache-2.0",
   "dependencies": {
-    "@adobe/aio-cli-plugin-runtime": "nimbella/aio-cli-plugin-runtime#v2020-12-01-1",
+    "@adobe/aio-cli-plugin-runtime": "nimbella/aio-cli-plugin-runtime#v2020-12-03-1",
     "@adobe/aio-lib-core-config": "^1.0.15",
     "@adobe/aio-lib-runtime": "^1.2.1",
     "@google-cloud/storage": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "author": "Nimbella Corporation",
   "license": "Apache-2.0",
   "dependencies": {
-    "@adobe/aio-cli-plugin-runtime": "nimbella/aio-cli-plugin-runtime#v2020-12-07-2",
+    "@adobe/aio-cli-plugin-runtime": "nimbella/aio-cli-plugin-runtime#v2020-12-07-3",
     "@adobe/aio-lib-core-config": "^1.0.15",
     "@adobe/aio-lib-runtime": "^1.2.1",
     "@google-cloud/storage": "5.3.0",

--- a/src/commands/action/create.ts
+++ b/src/commands/action/create.ts
@@ -14,7 +14,7 @@
 import { NimBaseCommand, NimLogger } from 'nimbella-deployer'
 import { inBrowser } from 'nimbella-deployer'
 import { flags } from '@oclif/command'
-import { RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime'
+import { default as RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime/src/RuntimeBaseCommand'
 const AioCommand: typeof RuntimeBaseCommand = require('@adobe/aio-cli-plugin-runtime/src/commands/runtime/action/create')
 
 export default class ActionCreate extends NimBaseCommand {

--- a/src/commands/action/delete.ts
+++ b/src/commands/action/delete.ts
@@ -12,7 +12,7 @@
  */
 
 import { NimBaseCommand, NimLogger, inBrowser } from 'nimbella-deployer'
-import { RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime'
+import { default as RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime/src/RuntimeBaseCommand'
 const AioCommand: typeof RuntimeBaseCommand = require('@adobe/aio-cli-plugin-runtime/src/commands/runtime/action/delete')
 import { prompt } from '../../ui'
 

--- a/src/commands/action/get.ts
+++ b/src/commands/action/get.ts
@@ -13,7 +13,7 @@
 
 import { NimBaseCommand, NimLogger, CaptureLogger, authPersister, getCredentials, getCredentialsForNamespace } from 'nimbella-deployer'
 import { inBrowser } from 'nimbella-deployer'
-import { RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime'
+import { default as RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime/src/RuntimeBaseCommand'
 const AioCommand: typeof RuntimeBaseCommand = require('@adobe/aio-cli-plugin-runtime/src/commands/runtime/action/get')
 
 export default class ActionGet extends NimBaseCommand {

--- a/src/commands/action/invoke.ts
+++ b/src/commands/action/invoke.ts
@@ -15,7 +15,7 @@ import { NimBaseCommand, NimLogger, inBrowser, CaptureLogger } from 'nimbella-de
 import { flags } from '@oclif/command'
 import { Action } from 'openwhisk'
 import { open } from '../../ui'
-import { RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime'
+import { default as RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime/src/RuntimeBaseCommand'
 import { createKeyValueArrayFromFlag, createKeyValueArrayFromFile } from '@adobe/aio-lib-runtime'
 import * as makeDebug from 'debug'
 const AioCommand: typeof RuntimeBaseCommand = require('@adobe/aio-cli-plugin-runtime/src/commands/runtime/action/invoke')

--- a/src/commands/action/invoke.ts
+++ b/src/commands/action/invoke.ts
@@ -15,7 +15,8 @@ import { NimBaseCommand, NimLogger, inBrowser, CaptureLogger } from 'nimbella-de
 import { flags } from '@oclif/command'
 import { Action } from 'openwhisk'
 import { open } from '../../ui'
-import { RuntimeBaseCommand, createKeyValueArrayFromFlag, createKeyValueArrayFromFile } from '@adobe/aio-cli-plugin-runtime'
+import { RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime'
+import { createKeyValueArrayFromFlag, createKeyValueArrayFromFile } from '@adobe/aio-lib-runtime'
 import * as makeDebug from 'debug'
 const AioCommand: typeof RuntimeBaseCommand = require('@adobe/aio-cli-plugin-runtime/src/commands/runtime/action/invoke')
 const ActionGet: typeof RuntimeBaseCommand = require('@adobe/aio-cli-plugin-runtime/src/commands/runtime/action/get')

--- a/src/commands/action/invoke.ts
+++ b/src/commands/action/invoke.ts
@@ -28,6 +28,7 @@ export default class ActionInvoke extends NimBaseCommand {
     // Ensure correct results in the workbench
     if (inBrowser) {
       this.debug('flags: %O', flags)
+      AioCommand.extraLoggingHeader = false // suppress header that causes CORS issues for us
       // Impose oclif convention that boolean flags are really boolean, since action invoke logic depends on this.
       // Perhaps this should be done earlier since it represents a difference between kui and oclif.  Kui also
       // handles the '--no-' prefix differently: --no-wait will set --wait to false, not --no-wait to true.  On the

--- a/src/commands/action/list.ts
+++ b/src/commands/action/list.ts
@@ -12,7 +12,7 @@
  */
 
 import { NimBaseCommand, NimLogger } from 'nimbella-deployer'
-import { RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime'
+import { default as RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime/src/RuntimeBaseCommand'
 const AioCommand: typeof RuntimeBaseCommand = require('@adobe/aio-cli-plugin-runtime/src/commands/runtime/action/list')
 
 export default class ActionList extends NimBaseCommand {

--- a/src/commands/action/update.ts
+++ b/src/commands/action/update.ts
@@ -12,7 +12,7 @@
  */
 
 import { NimBaseCommand, NimLogger } from 'nimbella-deployer'
-import { RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime'
+import { default as RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime/src/RuntimeBaseCommand'
 import { screenLegal, default as ActionCreate } from './create'
 const AioCommand: typeof RuntimeBaseCommand = require('@adobe/aio-cli-plugin-runtime/src/commands/runtime/action/update')
 

--- a/src/commands/activation/get.ts
+++ b/src/commands/activation/get.ts
@@ -12,7 +12,7 @@
  */
 
 import { NimBaseCommand, NimLogger } from 'nimbella-deployer'
-import { RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime'
+import { default as RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime/src/RuntimeBaseCommand'
 const AioCommand: typeof RuntimeBaseCommand = require('@adobe/aio-cli-plugin-runtime/src/commands/runtime/activation/get')
 
 export default class ActivationGet extends NimBaseCommand {

--- a/src/commands/activation/list.ts
+++ b/src/commands/activation/list.ts
@@ -13,7 +13,7 @@
 
 import { NimBaseCommand, NimLogger } from 'nimbella-deployer'
 import { inBrowser } from 'nimbella-deployer'
-import { RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime'
+import { default as RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime/src/RuntimeBaseCommand'
 const AioCommand: typeof RuntimeBaseCommand = require('@adobe/aio-cli-plugin-runtime/src/commands/runtime/activation/list')
 
 export default class ActivationList extends NimBaseCommand {

--- a/src/commands/activation/logs.ts
+++ b/src/commands/activation/logs.ts
@@ -12,7 +12,7 @@
  */
 
 import { NimBaseCommand, NimLogger } from 'nimbella-deployer'
-import { RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime'
+import { default as RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime/src/RuntimeBaseCommand'
 const AioCommand: typeof RuntimeBaseCommand = require('@adobe/aio-cli-plugin-runtime/src/commands/runtime/activation/logs')
 
 export default class ActivationLogs extends NimBaseCommand {

--- a/src/commands/activation/result.ts
+++ b/src/commands/activation/result.ts
@@ -12,7 +12,7 @@
  */
 
 import { NimBaseCommand, NimLogger } from 'nimbella-deployer'
-import { RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime'
+import { default as RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime/src/RuntimeBaseCommand'
 const AioCommand: typeof RuntimeBaseCommand = require('@adobe/aio-cli-plugin-runtime/src/commands/runtime/activation/result')
 
 export default class ActivationResult extends NimBaseCommand {

--- a/src/commands/namespace/get.ts
+++ b/src/commands/namespace/get.ts
@@ -13,7 +13,7 @@
 
 import { NimBaseCommand, NimLogger } from 'nimbella-deployer'
 import { inBrowser } from 'nimbella-deployer'
-import { RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime'
+import { default as RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime/src/RuntimeBaseCommand'
 const AioCommand: typeof RuntimeBaseCommand = require('@adobe/aio-cli-plugin-runtime/src/commands/runtime/namespace/get')
 
 export default class NamespaceGet extends NimBaseCommand {

--- a/src/commands/package/bind.ts
+++ b/src/commands/package/bind.ts
@@ -12,7 +12,7 @@
  */
 
 import { NimBaseCommand, NimLogger } from 'nimbella-deployer'
-import { RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime'
+import { default as RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime/src/RuntimeBaseCommand'
 const AioCommand: typeof RuntimeBaseCommand = require('@adobe/aio-cli-plugin-runtime/src/commands/runtime/package/bind')
 
 export default class PackageBind extends NimBaseCommand {

--- a/src/commands/package/create.ts
+++ b/src/commands/package/create.ts
@@ -12,7 +12,7 @@
  */
 
 import { NimBaseCommand, NimLogger } from 'nimbella-deployer'
-import { RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime'
+import { default as RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime/src/RuntimeBaseCommand'
 const AioCommand: typeof RuntimeBaseCommand = require('@adobe/aio-cli-plugin-runtime/src/commands/runtime/package/create')
 
 export default class PackageCreate extends NimBaseCommand {

--- a/src/commands/package/delete.ts
+++ b/src/commands/package/delete.ts
@@ -12,7 +12,7 @@
  */
 
 import { NimBaseCommand, NimLogger, inBrowser } from 'nimbella-deployer'
-import { RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime'
+import { default as RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime/src/RuntimeBaseCommand'
 import { flags } from '@oclif/command'
 const AioCommand: typeof RuntimeBaseCommand = require('@adobe/aio-cli-plugin-runtime/src/commands/runtime/package/delete')
 import { getCredentials, wipePackage, authPersister } from 'nimbella-deployer'

--- a/src/commands/package/get.ts
+++ b/src/commands/package/get.ts
@@ -12,7 +12,7 @@
  */
 
 import { NimBaseCommand, NimLogger } from 'nimbella-deployer'
-import { RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime'
+import { default as RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime/src/RuntimeBaseCommand'
 const AioCommand: typeof RuntimeBaseCommand = require('@adobe/aio-cli-plugin-runtime/src/commands/runtime/package/get')
 
 export default class PackageGet extends NimBaseCommand {

--- a/src/commands/package/list.ts
+++ b/src/commands/package/list.ts
@@ -12,7 +12,7 @@
  */
 
 import { NimBaseCommand, NimLogger } from 'nimbella-deployer'
-import { RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime'
+import { default as RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime/src/RuntimeBaseCommand'
 const AioCommand: typeof RuntimeBaseCommand = require('@adobe/aio-cli-plugin-runtime/src/commands/runtime/package/list')
 
 export default class PackageList extends NimBaseCommand {

--- a/src/commands/package/update.ts
+++ b/src/commands/package/update.ts
@@ -12,7 +12,7 @@
  */
 
 import { NimBaseCommand, NimLogger } from 'nimbella-deployer'
-import { RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime'
+import { default as RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime/src/RuntimeBaseCommand'
 const AioCommand: typeof RuntimeBaseCommand = require('@adobe/aio-cli-plugin-runtime/src/commands/runtime/package/update')
 
 export default class PackageUpdate extends NimBaseCommand {

--- a/src/commands/route/create.ts
+++ b/src/commands/route/create.ts
@@ -12,7 +12,7 @@
  */
 
 import { NimBaseCommand, NimLogger } from 'nimbella-deployer'
-import { RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime'
+import { default as RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime/src/RuntimeBaseCommand'
 const AioCommand: typeof RuntimeBaseCommand = require('@adobe/aio-cli-plugin-runtime/src/commands/runtime/route/create')
 
 export default class RouteCreate extends NimBaseCommand {

--- a/src/commands/route/delete.ts
+++ b/src/commands/route/delete.ts
@@ -12,7 +12,7 @@
  */
 
 import { NimBaseCommand, NimLogger } from 'nimbella-deployer'
-import { RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime'
+import { default as RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime/src/RuntimeBaseCommand'
 const AioCommand: typeof RuntimeBaseCommand = require('@adobe/aio-cli-plugin-runtime/src/commands/runtime/route/delete')
 
 export default class RouteDelete extends NimBaseCommand {

--- a/src/commands/route/get.ts
+++ b/src/commands/route/get.ts
@@ -12,7 +12,7 @@
  */
 
 import { NimBaseCommand, NimLogger } from 'nimbella-deployer'
-import { RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime'
+import { default as RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime/src/RuntimeBaseCommand'
 const AioCommand: typeof RuntimeBaseCommand = require('@adobe/aio-cli-plugin-runtime/src/commands/runtime/route/get')
 
 export default class RouteGet extends NimBaseCommand {

--- a/src/commands/route/list.ts
+++ b/src/commands/route/list.ts
@@ -12,7 +12,7 @@
  */
 
 import { NimBaseCommand, NimLogger } from 'nimbella-deployer'
-import { RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime'
+import { default as RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime/src/RuntimeBaseCommand'
 const AioCommand: typeof RuntimeBaseCommand = require('@adobe/aio-cli-plugin-runtime/src/commands/runtime/route/list')
 
 export default class RouteList extends NimBaseCommand {

--- a/src/commands/rule/create.ts
+++ b/src/commands/rule/create.ts
@@ -12,7 +12,7 @@
  */
 
 import { NimBaseCommand, NimLogger } from 'nimbella-deployer'
-import { RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime'
+import { default as RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime/src/RuntimeBaseCommand'
 const AioCommand: typeof RuntimeBaseCommand = require('@adobe/aio-cli-plugin-runtime/src/commands/runtime/rule/create')
 
 export default class RuleCreate extends NimBaseCommand {

--- a/src/commands/rule/delete.ts
+++ b/src/commands/rule/delete.ts
@@ -12,7 +12,7 @@
  */
 
 import { NimBaseCommand, NimLogger, inBrowser } from 'nimbella-deployer'
-import { RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime'
+import { default as RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime/src/RuntimeBaseCommand'
 const AioCommand: typeof RuntimeBaseCommand = require('@adobe/aio-cli-plugin-runtime/src/commands/runtime/rule/delete')
 import { prompt } from '../../ui'
 

--- a/src/commands/rule/disable.ts
+++ b/src/commands/rule/disable.ts
@@ -12,7 +12,7 @@
  */
 
 import { NimBaseCommand, NimLogger } from 'nimbella-deployer'
-import { RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime'
+import { default as RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime/src/RuntimeBaseCommand'
 const AioCommand: typeof RuntimeBaseCommand = require('@adobe/aio-cli-plugin-runtime/src/commands/runtime/rule/disable')
 
 export default class RuleDisable extends NimBaseCommand {

--- a/src/commands/rule/enable.ts
+++ b/src/commands/rule/enable.ts
@@ -12,7 +12,7 @@
  */
 
 import { NimBaseCommand, NimLogger } from 'nimbella-deployer'
-import { RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime'
+import { default as RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime/src/RuntimeBaseCommand'
 const AioCommand: typeof RuntimeBaseCommand = require('@adobe/aio-cli-plugin-runtime/src/commands/runtime/rule/enable')
 
 export default class RuleEnable extends NimBaseCommand {

--- a/src/commands/rule/get.ts
+++ b/src/commands/rule/get.ts
@@ -12,7 +12,7 @@
  */
 
 import { NimBaseCommand, NimLogger } from 'nimbella-deployer'
-import { RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime'
+import { default as RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime/src/RuntimeBaseCommand'
 const AioCommand: typeof RuntimeBaseCommand = require('@adobe/aio-cli-plugin-runtime/src/commands/runtime/rule/get')
 
 export default class RuleGet extends NimBaseCommand {

--- a/src/commands/rule/list.ts
+++ b/src/commands/rule/list.ts
@@ -12,7 +12,7 @@
  */
 
 import { NimBaseCommand, NimLogger } from 'nimbella-deployer'
-import { RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime'
+import { default as RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime/src/RuntimeBaseCommand'
 const AioCommand: typeof RuntimeBaseCommand = require('@adobe/aio-cli-plugin-runtime/src/commands/runtime/rule/list')
 
 export default class RuleList extends NimBaseCommand {

--- a/src/commands/rule/status.ts
+++ b/src/commands/rule/status.ts
@@ -12,7 +12,7 @@
  */
 
 import { NimBaseCommand, NimLogger } from 'nimbella-deployer'
-import { RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime'
+import { default as RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime/src/RuntimeBaseCommand'
 const AioCommand: typeof RuntimeBaseCommand = require('@adobe/aio-cli-plugin-runtime/src/commands/runtime/rule/status')
 
 export default class RuleStatus extends NimBaseCommand {

--- a/src/commands/rule/update.ts
+++ b/src/commands/rule/update.ts
@@ -12,7 +12,7 @@
  */
 
 import { NimBaseCommand, NimLogger } from 'nimbella-deployer'
-import { RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime'
+import { default as RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime/src/RuntimeBaseCommand'
 const AioCommand: typeof RuntimeBaseCommand = require('@adobe/aio-cli-plugin-runtime/src/commands/runtime/rule/update')
 
 export default class RuleUpdate extends NimBaseCommand {

--- a/src/commands/trigger/create.ts
+++ b/src/commands/trigger/create.ts
@@ -12,7 +12,7 @@
  */
 
 import { NimBaseCommand, NimLogger } from 'nimbella-deployer'
-import { RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime'
+import { default as RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime/src/RuntimeBaseCommand'
 const AioCommand: typeof RuntimeBaseCommand = require('@adobe/aio-cli-plugin-runtime/src/commands/runtime/trigger/create')
 
 export default class TriggerCreate extends NimBaseCommand {

--- a/src/commands/trigger/delete.ts
+++ b/src/commands/trigger/delete.ts
@@ -12,7 +12,7 @@
  */
 
 import { NimBaseCommand, NimLogger, inBrowser } from 'nimbella-deployer'
-import { RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime'
+import { default as RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime/src/RuntimeBaseCommand'
 const AioCommand: typeof RuntimeBaseCommand = require('@adobe/aio-cli-plugin-runtime/src/commands/runtime/trigger/delete')
 import { prompt } from '../../ui'
 

--- a/src/commands/trigger/fire.ts
+++ b/src/commands/trigger/fire.ts
@@ -12,7 +12,7 @@
  */
 
 import { NimBaseCommand, NimLogger } from 'nimbella-deployer'
-import { RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime'
+import { default as RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime/src/RuntimeBaseCommand'
 const AioCommand: typeof RuntimeBaseCommand = require('@adobe/aio-cli-plugin-runtime/src/commands/runtime/trigger/fire')
 
 export default class TriggerFire extends NimBaseCommand {

--- a/src/commands/trigger/get.ts
+++ b/src/commands/trigger/get.ts
@@ -12,7 +12,7 @@
  */
 
 import { NimBaseCommand, NimLogger } from 'nimbella-deployer'
-import { RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime'
+import { default as RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime/src/RuntimeBaseCommand'
 const AioCommand: typeof RuntimeBaseCommand = require('@adobe/aio-cli-plugin-runtime/src/commands/runtime/trigger/get')
 
 export default class TriggerGet extends NimBaseCommand {

--- a/src/commands/trigger/list.ts
+++ b/src/commands/trigger/list.ts
@@ -12,7 +12,7 @@
  */
 
 import { NimBaseCommand, NimLogger } from 'nimbella-deployer'
-import { RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime'
+import { default as RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime/src/RuntimeBaseCommand'
 const AioCommand: typeof RuntimeBaseCommand = require('@adobe/aio-cli-plugin-runtime/src/commands/runtime/trigger/list')
 
 export default class TriggerList extends NimBaseCommand {

--- a/src/commands/trigger/update.ts
+++ b/src/commands/trigger/update.ts
@@ -12,7 +12,7 @@
  */
 
 import { NimBaseCommand, NimLogger } from 'nimbella-deployer'
-import { RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime'
+import { default as RuntimeBaseCommand } from '@adobe/aio-cli-plugin-runtime/src/RuntimeBaseCommand'
 const AioCommand: typeof RuntimeBaseCommand = require('@adobe/aio-cli-plugin-runtime/src/commands/runtime/trigger/update')
 
 export default class TriggerUpdate extends NimBaseCommand {


### PR DESCRIPTION
Our fork of aio-cli-plugin-runtime is being rebased on the latest code from Adobe (going from version 1.7.3 to version 3.0.0).

The purpose of this PR is to adjust to those changes.