### PR TITLE
Support sequences

### DIFF
--- a/deployer/src/NimBaseCommand.ts
+++ b/deployer/src/NimBaseCommand.ts
@@ -126,7 +126,7 @@ class AioCommand extends Command {
   logJSON(_hdr: string, _entity: Record<string, unknown>) { /* no-op */ }
   table(data: Record<string, unknown>[], _columns: Record<string, unknown>, _options: Record<string, unknown> = {}) { /* no-op */ }
   async run(_argv?: string[]) { /* no-op */ }
-  setNamespaceHeaderOmission(newValue: boolean) { /* no-op */ }
+  setNamespaceHeaderOmission(_newValue: boolean) { /* no-op */ }
 }
 
 // The base for all our commands, including the ones that delegate to aio.  There are methods designed to be called from the

--- a/deployer/src/api.ts
+++ b/deployer/src/api.ts
@@ -23,7 +23,6 @@ import {
 import { openBucketClient } from './deploy-to-bucket'
 import { buildAllActions, buildWeb } from './finder-builder'
 import * as openwhisk from 'openwhisk'
-import * as path from 'path'
 import { getCredentialsForNamespace, getCredentials, Persister, recordNamespaceOwnership } from './credentials'
 import { makeIncluder } from './includer'
 import * as makeDebug from 'debug'
@@ -306,13 +305,13 @@ export async function prepareToDeploy(inputSpec: DeployStructure, owOptions: OWO
   const { web, packages } = inputSpec
   if (web && web.length > 0 && inputSpec.actionWrapPackage) {
     try {
+      const wrapPackage = inputSpec.actionWrapPackage
       const wrapping = web.map(res => {
         if (!res.mimeType) {
           throw new Error(`Could not deploy web resource ${res.filePath}; mime type cannot be determined`)
         }
-        return actionWrap(res, inputSpec.reader)
+        return actionWrap(res, inputSpec.reader, wrapPackage)
       })
-      const wrapPackage = inputSpec.actionWrapPackage
       return Promise.all(wrapping).then(wrapped => {
         // If wrapPackage is already in the inputSpec, add the new actions to it.  Otherwise, make a new PackageSpec
         const existing: PackageSpec[] = packages.filter(pkg => pkg.name === wrapPackage)

--- a/deployer/src/deploy-struct.ts
+++ b/deployer/src/deploy-struct.ts
@@ -49,6 +49,7 @@ export interface PackageSpec {
 // Describes one action
 export interface ActionSpec {
     name: string // The name of the action
+    package: string // The name of the package where action appears ('default' if no package)
     // The following are used to assemble 'exec'.  Currently, you can't specify exec directly
     file?: string // The path to the file comprising the action (possibly a zip file)
     displayFile?: string // The file path to display in messages
@@ -58,6 +59,7 @@ export interface ActionSpec {
     binary?: boolean // Indicates the need for base64 encoding
     zipped?: boolean // (Ignored unless binary) indicates that the binary object is a zip archive
     // End of 'exec' properties
+    sequence?: string[] // Indicates that this action is a sequence and provides its components.  Mutually exclusive with the 'exec' options
     web?: any // like --web on the CLI; expands to multiple annotations.  Project reader assigns true unless overridden.
     webSecure?: any // like --web-secure on the CLI.  False unless overridden
     annotations?: Dict // 'web' and 'webSecure' are merged with what's here iff present
@@ -152,6 +154,7 @@ export interface DeployStructure {
     error?: Error // Records an error in reading or preparing, or a terminal error in building; the structure should not be used
     webBuildError?: Error // Indicates an error in building the web component; the structure is usable but the failure should be reported
     webBuildResult?: string // activation id of remote build
+    sequences?: ActionSpec[] // detected during action deployment and deferred until ordinary actions are deployed
 }
 
 // Structure declaring ownership of the targetNamespace by this project.  Ownership is recorded only locally (in the credential store)

--- a/deployer/src/deploy.ts
+++ b/deployer/src/deploy.ts
@@ -284,7 +284,7 @@ function deployAction(action: ActionSpec, spec: DeployStructure, pkgIsClean: boo
     }).then((code: string) => deployActionFromCodeOrSequence(action, spec, code, undefined, pkgIsClean))
       .catch(err => Promise.resolve(wrapError(err, context)))
   } else {
-    return Promise.resolve(wrapError(new Error('Action is not a sequence and does not appear in the project structure'), context))
+    return Promise.resolve(wrapError(new Error('Action is named in the config but does not exist in the project'), context))
   }
 }
 

--- a/deployer/src/project-reader.ts
+++ b/deployer/src/project-reader.ts
@@ -216,8 +216,7 @@ function mergePackages(fs: PackageSpec[], config: PackageSpec[]): PackageSpec[] 
     if (already) {
       merge[pkg.name] = mergePackage(already, pkg)
     } else {
-      // For now, a package cannot be declared _only_ in the config
-      throw new Error(`Package '${pkg.name}' is named in the config but does not exist in the project`)
+      merge[pkg.name] = pkg
     }
   })
   const ans: PackageSpec[] = []
@@ -272,8 +271,7 @@ function mergeActions(fs: ActionSpec[], config: ActionSpec[]): ActionSpec[] {
     if (already) {
       merge[action.name] = mergeAction(already, action)
     } else {
-      // For now, an action cannot be declared _only_ in the config
-      throw new Error(`Action '${action.name}' is named in the config but does not exist in the project`)
+      merge[action.name] = action
     }
   })
   const ans: ActionSpec[] = []
@@ -365,7 +363,7 @@ function readPackage(pkgPath: string, displayPath: string, pkgName: string, incl
           throw duplicateName(name, before, runtime)
         }
         seen[name] = runtime
-        promises.push(Promise.resolve({ name, file, displayFile, runtime, binary, zipped }))
+        promises.push(Promise.resolve({ name, file, displayFile, runtime, binary, zipped, package: pkgName }))
       } else if (item.isDirectory) {
         // Build-dependent action or renamed action
         if (!includer.isActionIncluded(pkgName, item.name)) continue
@@ -375,7 +373,7 @@ function readPackage(pkgPath: string, displayPath: string, pkgName: string, incl
         }
         seen[item.name] = '*'
         promises.push(getBuildForAction(file, reader).then(build => {
-          return { name: item.name, file, displayFile, build }
+          return { name: item.name, file, displayFile, build, package: pkgName }
         }))
       }
     }

--- a/deployer/src/project-reader.ts
+++ b/deployer/src/project-reader.ts
@@ -216,6 +216,9 @@ function mergePackages(fs: PackageSpec[], config: PackageSpec[]): PackageSpec[] 
     if (already) {
       merge[pkg.name] = mergePackage(already, pkg)
     } else {
+      (pkg.actions || []).forEach(action => {
+        action.package = pkg.name
+      })
       merge[pkg.name] = pkg
     }
   })
@@ -234,7 +237,7 @@ function mergePackage(fs: PackageSpec, config: PackageSpec): PackageSpec {
   const ans = Object.assign({}, fs, config)
   if (fsActions && fsActions.length > 0) {
     if (cfgActions && cfgActions.length > 0) {
-      ans.actions = mergeActions(fsActions, cfgActions)
+      ans.actions = mergeActions(fsActions, cfgActions, config.name)
     } else {
       ans.actions = fsActions
     }
@@ -261,7 +264,7 @@ function adjustWebExportFlags(pkgs: PackageSpec[]) {
 
 // Merge the actions portion of a PackageSpec in config, if any, into the corresponding PackageSpec actions read from the file system.
 // The merge key is the action name.
-function mergeActions(fs: ActionSpec[], config: ActionSpec[]): ActionSpec[] {
+function mergeActions(fs: ActionSpec[], config: ActionSpec[], pkgName: string): ActionSpec[] {
   const merge = {}
   fs.forEach(action => {
     merge[action.name] = action
@@ -271,6 +274,7 @@ function mergeActions(fs: ActionSpec[], config: ActionSpec[]): ActionSpec[] {
     if (already) {
       merge[action.name] = mergeAction(already, action)
     } else {
+      action.package = pkgName
       merge[action.name] = action
     }
   })

--- a/deployer/src/util.ts
+++ b/deployer/src/util.ts
@@ -442,6 +442,11 @@ function validateActionSpec(arg: Record<string, any>): string {
         return `'${item}' member of an 'action' must be a boolean`
       }
       break
+    case 'sequence':
+      if (!Array.isArray(arg[item]) || arg[item].length === 0 || (typeof arg[item][0]) !== 'string') {
+        return `'${item}' member of an 'action' must be an array of one or more strings naming actions`
+      }
+      break
     case 'web':
       if (!(typeof arg[item] === 'boolean' || arg[item] === 'raw')) {
         return `${item} member of an 'action' must be a boolean or the string 'raw'`

--- a/src/generator/project.ts
+++ b/src/generator/project.ts
@@ -126,7 +126,8 @@ function generateSample(kind: string, config: DeployStructure | undefined, sampl
       parameters: {},
       environment: {},
       annotations: {},
-      limits: {}
+      limits: {},
+      package: 'default'
     }
     defPkg.actions.push(action)
   }
@@ -135,17 +136,17 @@ function generateSample(kind: string, config: DeployStructure | undefined, sampl
 function mapLanguage(kind: string) {
   let [language, variant] = kind.split(':')
   switch (language) {
-    case 'js':
-      language = 'nodejs'
-      break
-    case 'ts':
-      language = 'typescript'
-      break
-    case 'py':
-      language = 'python'
-      break
-    default:
-      break
+  case 'js':
+    language = 'nodejs'
+    break
+  case 'ts':
+    language = 'typescript'
+    break
+  case 'py':
+    language = 'python'
+    break
+  default:
+    break
   }
   return `${language}:${variant}`
 }


### PR DESCRIPTION
This PR adds the `sequence` property to members of the `actions` object in `project.yml`.   The value of this property is an array of action names which are taken to be the members of an openwhisk sequence action.

- the action names 
    - may begin with a slash and are assumed to be fully qualified (e.g. may be defined in a different namespace)
    - may be package-qualified (with a single slash separator) assumed to be in the target namespace
    - may be simple names (assumed to be defined in the default package of the target namespace)
- if an action thus denoted is in the target namespace but is not being deployed in the current deployment
    - an information message is issued to that effect but it is not an error
    - the deployer does not check specifically for whether such actions have been deployed to the backend, so, the deployment may fail at the backend
    - the deployer will deploy all ordinary actions and await outcomes before deploying sequences
- temporarily, an action included in a sequence cannot itself be a sequence specified in the same deployment (this will be relaxed in future but dependency cycles will remain illegal)
- if an action is defined as a sequence, it cannot also have a code body (ie. it cannot appear in the project structure in the usual way) and cannot declare `runtime`, `binary`, or `main` attributes. 
