### PR TITLE
Reveal the remote-build capability

### DIFF
--- a/deployer/src/util.ts
+++ b/deployer/src/util.ts
@@ -87,9 +87,7 @@ function isRealBuild(buildField: string): boolean {
 
 // Replace a build field with 'remote' if it is supposed to be remote according to flags, directives, environment
 function locateBuild(buildField: string, remoteRequested: boolean, remoteRequired: boolean, localRequired: boolean) {
-  // TODO: uncomment the 'inBrowser' test when ready.  We are currently hiding remote build capability because
-  // the client side will be merged before the server side.
-  if (isRealBuild(buildField) && (/* inBrowser || */ remoteRequired || (remoteRequested && !localRequired))) {
+  if (isRealBuild(buildField) && ( inBrowser || remoteRequired || (remoteRequested && !localRequired))) {
     return 'remote'
   }
   return buildField

--- a/src/commands/project/deploy.ts
+++ b/src/commands/project/deploy.ts
@@ -34,7 +34,7 @@ export class ProjectDeploy extends NimBaseCommand {
     'web-local': flags.string({ description: 'A local directory to receive web deploy, instead of uploading'}),
     include: flags.string({ description: 'Project portions to include' }),
     exclude: flags.string({ description: 'Project portions to exclude' }),
-    'remote-build': flags.boolean({ description: 'Run builds remotely', hidden: true }),
+    'remote-build': flags.boolean({ description: 'Run builds remotely' }),
     incremental: flags.boolean({ description: 'Deploy only changes since last deploy' }),
     'anon-github': flags.boolean({ description: 'Attempt GitHub deploys anonymously'} ),
     ...NimBaseCommand.flags


### PR DESCRIPTION
This will remove the hiding logic so that the remote build flag shows up in help and remote builds are tried in the workbench without the need to specify the flag.