### PR TITLE
Support enterprise github in "deploy from github" feature

### DIFF
--- a/deployer/src/NimBaseCommand.ts
+++ b/deployer/src/NimBaseCommand.ts
@@ -318,6 +318,13 @@ Repeat the command with the '--verbose' flag for more detail`
   if ((pretty || '').toString().trim()) {
     msg = msg ? `${msg}: ${pretty}` : pretty
   }
+  if (!msg) {
+    if (err.status) {
+      msg = getStatusCode(err.status)
+    } else {
+      msg = 'unknown error'
+    }
+  }
   debug('improved msg: %s', msg)
   return msg
 }

--- a/deployer/src/github.ts
+++ b/deployer/src/github.ts
@@ -100,7 +100,17 @@ export function parseGithubRef(projectPath: string): GithubDef {
   // Add auth and optionally the baseUrl
   const path = slashSplit.slice(2).join('/')
   const rawAuth = getGithubAuth(authPersister)
-  const [ auth, baseUrl ] = (rawAuth || '').split('@')
+  let [ auth, baseUrl ] = (rawAuth || '').split('@')
+  if (baseUrl) {
+    debug('original baseUrl: %s', baseUrl)
+    if (!baseUrl.includes('api')) {
+      baseUrl += '/api/v3'
+    } 
+    if (!baseUrl.includes(':')) {
+      baseUrl = "https://" + baseUrl
+    }
+    debug('modified baseUrl: %s', baseUrl)
+  }
   return { owner, repo, path, auth, baseUrl, ref }
 }
 

--- a/deployer/src/github.ts
+++ b/deployer/src/github.ts
@@ -39,6 +39,7 @@ export interface GithubDef {
     repo: string
     path: string
     auth?: string
+    baseUrl?: string
     ref?: string
 }
 
@@ -96,10 +97,11 @@ export function parseGithubRef(projectPath: string): GithubDef {
   if (repo.endsWith('.git')) {
     repo = repo.slice(0, repo.length - 4)
   }
-  // Add auth
+  // Add auth and optionally the baseUrl
   const path = slashSplit.slice(2).join('/')
-  const auth = getGithubAuth(authPersister)
-  return { owner, repo, path, auth, ref }
+  const rawAuth = getGithubAuth(authPersister)
+  const [ auth, baseUrl ] = (rawAuth || '').split('@')
+  return { owner, repo, path, auth, baseUrl, ref }
 }
 
 // Fetch a project into the cache, returning a path to its location
@@ -118,7 +120,7 @@ export async function fetchProject(def: GithubDef, userAgent: string): Promise<s
 
 // Make a github client
 export function makeClient(def: GithubDef, userAgent: string): Octokit {
-  return new Octokit({ auth: def.auth, userAgent })
+  return new Octokit({ auth: def.auth, baseUrl: def.baseUrl, userAgent })
 }
 
 // Get contents from a github repo at specific coordinates (path and ref).  All but the path


### PR DESCRIPTION
The ability to deploy from github has so far been bound to `github.com` because it uses `octokit` and, in constructing the `octokit` object, it does not specify a `baseUrl`.   The default `baseUrl` (`https://api.github.com`) is thus assumed.

This change enables enterprise github (and perhaps other api-compatible github servers) to be used in lieu of `github.com`.

1.  When github credentials are established as before, they will continue use the default endpoint `api.github.com`.
2. However, when github credentials are entered manually (by specifying a username and token), the token can optionally specify an alternate endpoint by using the form `<token>@<endpoint>`.
    - if the endpoint string does not include `api`, the path `/api/v3` is appended
    - if the endpoint string does not include ':', the prefix `https://` is prepended
3.  General improvements to the management of multiple github credentials are beyond the scope of this PR but might be considered as a follow-on.