### PR TITLE
[project:watch] fix temp file error

### DIFF
--- a/deployer/package.json
+++ b/deployer/package.json
@@ -17,6 +17,7 @@
     "@nimbella/storage-s3": "0.0.11",
     "@oclif/command": "^1",
     "@octokit/rest": "16.36.0",
+    "anymatch": "^3.1.1",
     "adm-zip": "^0.4.16",
     "archiver": "^3.0.0",
     "axios": "^0.21.1",

--- a/deployer/src/NimBaseCommand.ts
+++ b/deployer/src/NimBaseCommand.ts
@@ -147,7 +147,7 @@ export abstract class NimBaseCommand extends Command implements NimLogger {
   // Usage model for when running with kui
   usage: Record<string, any>
 
-  // A general way of running help from a cammand.  Use _help in oclif and helpHelper in kui
+  // A general way of running help from a command.  Use _help in oclif and helpHelper in kui
   doHelp(): void {
     if (helpHelper && this.usage) {
       helpHelper(this.usage)

--- a/deployer/src/api.ts
+++ b/deployer/src/api.ts
@@ -335,7 +335,7 @@ export async function prepareToDeploy(inputSpec: DeployStructure, owOptions: OWO
 // Utility to convert errors into useful messages.   Usually, this just means getting the message field from the error but there
 // is logic to recognize the particular error pattern used by OW
 export function getMessageFromError(err: any): string {
-  // Althought we attempt to say that all errors have type Error, in the loosy-goosy untyped world of Javascript this is easily violated.
+  // Although we attempt to say that all errors have type Error, in the loosy-goosy untyped world of Javascript this is easily violated.
   // Sometimes 'err' is just a string
   if (typeof err === 'string') {
     return err

--- a/deployer/src/finder-builder.ts
+++ b/deployer/src/finder-builder.ts
@@ -14,9 +14,9 @@
 import { spawn } from 'child_process'
 import { DeployStructure, ActionSpec, PackageSpec, WebResource, BuildTable, Flags, ProjectReader, PathKind, Feedback, Credentials } from './deploy-struct'
 import {
-  SYSTEM_EXCLUDE_PATTERNS, actionFileToParts, filterFiles, mapPackages, mapActions, convertToResources, convertPairsToResources,
+  actionFileToParts, filterFiles, mapPackages, mapActions, convertToResources, convertPairsToResources,
   promiseFilesAndFilterFiles, agreeOnRuntime,
-  canonicalRuntime, getBestProjectName
+  canonicalRuntime, getBestProjectName, getExclusionList
 } from './util'
 import * as path from 'path'
 import * as fs from 'fs'
@@ -1037,7 +1037,7 @@ function buildScriptExists(filepath: string): boolean {
 // also don't add an entry for .include (or .source) since that case is driven by a fixed set of files and not by scanning a directory.
 function getIgnores(dir: string, reader: ProjectReader): Promise<Ignore> {
   const filePath = path.join(dir, '.ignore')
-  const fixedItems = ['.ignore', '.build', 'build.sh', 'build.cmd', ZIP_TARGET, ...SYSTEM_EXCLUDE_PATTERNS]
+  const fixedItems = ['.ignore', '.build', 'build.sh', 'build.cmd', ZIP_TARGET, ...getExclusionList()]
   return readFileAsList(filePath, reader).then(items => {
     return ignore().add(items.concat(fixedItems))
   }).catch(() => {

--- a/deployer/src/finder-builder.ts
+++ b/deployer/src/finder-builder.ts
@@ -14,7 +14,7 @@
 import { spawn } from 'child_process'
 import { DeployStructure, ActionSpec, PackageSpec, WebResource, BuildTable, Flags, ProjectReader, PathKind, Feedback, Credentials } from './deploy-struct'
 import {
-  FILES_TO_SKIP, actionFileToParts, filterFiles, mapPackages, mapActions, convertToResources, convertPairsToResources,
+  SYSTEM_EXCLUDE_PATTERNS, actionFileToParts, filterFiles, mapPackages, mapActions, convertToResources, convertPairsToResources,
   promiseFilesAndFilterFiles, agreeOnRuntime,
   canonicalRuntime, getBestProjectName
 } from './util'
@@ -1037,7 +1037,7 @@ function buildScriptExists(filepath: string): boolean {
 // also don't add an entry for .include (or .source) since that case is driven by a fixed set of files and not by scanning a directory.
 function getIgnores(dir: string, reader: ProjectReader): Promise<Ignore> {
   const filePath = path.join(dir, '.ignore')
-  const fixedItems = ['.ignore', '.build', 'build.sh', 'build.cmd', ZIP_TARGET, ...FILES_TO_SKIP]
+  const fixedItems = ['.ignore', '.build', 'build.sh', 'build.cmd', ZIP_TARGET, ...SYSTEM_EXCLUDE_PATTERNS]
   return readFileAsList(filePath, reader).then(items => {
     return ignore().add(items.concat(fixedItems))
   }).catch(() => {

--- a/deployer/src/finder-builder.ts
+++ b/deployer/src/finder-builder.ts
@@ -54,7 +54,7 @@ export function getBuildForAction(filepath: string, reader: ProjectReader): Prom
 
 // Build all the actions in an array of PackageSpecs, returning a new array of PackageSpecs.  We try to return
 // undefined for the case where no building occurred at all, since we are obligated to return a full array if
-// any building occured, even if most things weren't subject to building.
+// any building occurred, even if most things weren't subject to building.
 export function buildAllActions(spec: DeployStructure): Promise<PackageSpec[]> {
   const packages = spec.packages
   if (!packages || packages.length === 0) {
@@ -784,7 +784,7 @@ function singleFileBuilder(action: ActionSpec, file: string): Promise<ActionSpec
   delete newMeta.name
   newMeta.web = true
   // After a build, only the file, zipped, and binary flags take precedence over what's in the action already.
-  // Metadata calcuated from the file name is filled in, as is the default for web, but these apply only if not
+  // Metadata calculated from the file name is filled in, as is the default for web, but these apply only if not
   // already specified in the action (except for binary and zipped, which always change to match the build result).
   const { binary, zipped } = newMeta
   const newAction = Object.assign(newMeta, action, { file, binary, zipped })

--- a/deployer/src/index.ts
+++ b/deployer/src/index.ts
@@ -31,7 +31,7 @@ export {
   switchGithubAccount, getPostmanKeys, deletePostmanKey, switchPostmanKey, addPostmanKey, getPostmanCurrentKey, addCommanderData, recordNamespaceOwnership, nimbellaDir, setInBrowser
 } from './credentials'
 export { cleanBucket, restore404Page, makeStorageClient } from './deploy-to-bucket'
-export { extFromRuntime, wskRequest, inBrowser, RuntimeTable, delay, writeSliceResult, getBestProjectName, isTextType, renamePackage } from './util'
+export { extFromRuntime, wskRequest, inBrowser, RuntimeTable, delay, writeSliceResult, getBestProjectName, isTextType, renamePackage, getExclusionList, isExcluded, SYSTEM_EXCLUDE_PATTERNS } from './util'
 export { GithubDef, isGithubRef, parseGithubRef, fetchProject } from './github'
 export { NimBaseCommand, NimLogger, parseAPIHost, NimFeedback, disambiguateNamespace, CaptureLogger } from './NimBaseCommand'
 export { deleteSlice } from './slice-reader'

--- a/deployer/src/project-reader.ts
+++ b/deployer/src/project-reader.ts
@@ -122,7 +122,7 @@ export async function readTopLevel(filePath: string, env: string, includer: Incl
       feedback.warn('Warning: found %s but no %s', notconfig, CONFIG_FILE)
     }
     if (githubPath) {
-      debug('githhub path was %s', githubPath)
+      debug('github path was %s', githubPath)
       debug('filePath is %s', filePath)
     }
     const ans = { web, packages, config, strays, filePath, env, githubPath, includer, reader, feedback }

--- a/deployer/src/util.ts
+++ b/deployer/src/util.ts
@@ -39,12 +39,12 @@ export const FILES_TO_SKIP = ['.gitignore', '.DS_Store']
 
 // List of files/paths to be ignored, add https://github.com/micromatch/anymatch compatible definitions
 export const SYSTEM_EXCLUDE_PATTERNS = ['.ignore', '.build', 'build.sh', 'build.cmd', '__deployer__.zip', '.gitignore', '.DS_Store',
-  (_: string | string[]): boolean => _.includes('.nimbella'),
-  (_: string | string[]): boolean => _.includes('_tmp_'),
-  (_: string | string[]): boolean => _.includes('.#'),
-  (_: string): boolean => _.endsWith('~'),
-  (_: string): boolean => _.endsWith('.swp'),
-  (_: string): boolean => _.endsWith('.swx')
+  '*.nimbella*',
+  '*_tmp_*',
+  '*.#*',
+  '*~',
+  '*.swp',
+  '*.swx'
 ]
 
 // Flag indicating running in browser
@@ -790,7 +790,7 @@ function binaryFromExt(ext: string): boolean {
 export function filterFiles(entries: PathKind[]): PathKind[] {
   return entries.filter(entry => {
     if (!entry.isDirectory) {
-      return !entry.name.endsWith('~') && FILES_TO_SKIP.every(_ => entry.name !== _)
+      return !anymatch(SYSTEM_EXCLUDE_PATTERNS, entry.name)
     } else {
       return entry
     }
@@ -799,8 +799,7 @@ export function filterFiles(entries: PathKind[]): PathKind[] {
 
 // Emulates promiseFiles (from node-dir) using a ProjectReader and adds filtering like filterFiles
 export function promiseFilesAndFilterFiles(root: string, reader: ProjectReader): Promise<string[]> {
-  return promiseFiles(root, reader).then((items: string[]) => items.filter((item: string) => !item.endsWith('~') &&
-        FILES_TO_SKIP.every(_ => item !== _)))
+  return promiseFiles(root, reader).then((items: string[]) => items.filter((item: string) => !anymatch(SYSTEM_EXCLUDE_PATTERNS, item)))
 }
 
 // Emulate promiseFiles using a ProjectReader

--- a/deployer/src/util.ts
+++ b/deployer/src/util.ts
@@ -1386,15 +1386,15 @@ export function renamePackage(spec: DeployStructure, oldName: string, newName: s
 }
 
 // Checks if a given pattern matches exclusion list, defined by system or user via global .exclude file.
-export function isExcluded(match: string): boolean {
-  return anymatch(getExclusionList(), match)
+export function isExcluded(project: string, match: string): boolean {
+  return anymatch(getExclusionList(project), match)
 }
 
 // Returns full list of exclusion patterns, predefined or listed in the global .exclude file.
-export function getExclusionList(): string[] {
+export function getExclusionList(project: string): string[] {
   let userDefinedPatterns = []
   try {
-    const globalExcludeFile = path.join(process.cwd(), '.exclude')
+    const globalExcludeFile = path.join(project || process.cwd(), '.exclude')
     userDefinedPatterns = fs.readFileSync(globalExcludeFile).toString().split('\n').filter(e => e.toString().trim() !== '')
   } catch (e) {
     debug(e.message)

--- a/deployer/src/util.ts
+++ b/deployer/src/util.ts
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2019 - present Nimbella Corp.
- *
- * This file is licensed to you under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License. You may obtain a copy
- * of the License at http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
- * OF ANY KIND, either express or implied. See the License for the specific language
- * governing permissions and limitations under the License.
- */
+* Copyright (c) 2019 - present Nimbella Corp.
+*
+* This file is licensed to you under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License. You may obtain a copy
+* of the License at http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software distributed under
+* the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+* OF ANY KIND, either express or implied. See the License for the specific language
+* governing permissions and limitations under the License.
+*/
 
 import {
   DeployStructure, DeployResponse, DeploySuccess, DeployKind, ActionSpec, PackageSpec, Feedback,
@@ -28,12 +28,24 @@ import * as randomstring from 'randomstring'
 import * as crypto from 'crypto'
 import * as yaml from 'js-yaml'
 import * as makeDebug from 'debug'
+import anymatch from 'anymatch'
 import { parseGithubRef } from './github'
 import { StorageProvider } from '@nimbella/storage-provider'
 const debug = makeDebug('nim:deployer:util')
 
+// TODO: Deprecate this use SYSTEM_EXCLUDE_PATTERNS instead
 // List of files to skip as actions inside packages, or from auto-zipping
 export const FILES_TO_SKIP = ['.gitignore', '.DS_Store']
+
+// List of files/paths to be ignored, add https://github.com/micromatch/anymatch compatible definitions
+export const SYSTEM_EXCLUDE_PATTERNS = ['.ignore', '.build', 'build.sh', 'build.cmd', '__deployer__.zip', '.gitignore', '.DS_Store',
+  (_: string | string[]): boolean => _.includes('.nimbella'),
+  (_: string | string[]): boolean => _.includes('_tmp_'),
+  (_: string | string[]): boolean => _.includes('.#'),
+  (_: string): boolean => _.endsWith('~'),
+  (_: string): boolean => _.endsWith('.swp'),
+  (_: string): boolean => _.endsWith('.swx')
+]
 
 // Flag indicating running in browser
 export const inBrowser = (typeof process === 'undefined') || (!process.release) || (process.release.name !== 'node')
@@ -1065,7 +1077,7 @@ export async function getDeployerAnnotation(project: string, githubPath: string)
 
 function deployerAnnotationFromGithub(githubPath: string): DeployerAnnotation {
   const def = parseGithubRef(githubPath)
-  const repository = `githhub:${def.owner}/${def.repo}`
+  const repository = `github:${def.owner}/${def.repo}`
   return { digest: undefined, user: 'cloud', repository, projectPath: def.path, commit: def.ref || 'master' }
 }
 
@@ -1233,7 +1245,7 @@ export function writeProjectStatus(project: string, results: DeployResponse, rep
   let versionList: VersionEntry[] = []
   const versionFile = path.join(statusDir, 'versions.json')
   if (fs.existsSync(versionFile)) {
-    debug('version file alread exists')
+    debug('version file already exists')
     const old = JSON.parse(String(fs.readFileSync(versionFile)))
     if (Array.isArray(old)) {
       versionList = old
@@ -1372,4 +1384,22 @@ export function renamePackage(spec: DeployStructure, oldName: string, newName: s
     }
   }
   return spec
+}
+
+// Checks if a given pattern matches exclusion list, defined by system or user via global .exclude file.
+export function isExcluded(match: string): boolean {
+  return anymatch(getExclusionList(), match)
+}
+
+// Returns full list of exclusion patterns, predefined or listed in the global .exclude file.
+export function getExclusionList(): string[] {
+  let userDefinedPatterns = []
+  try {
+    const globalExcludeFile = path.join(process.cwd(), '.exclude')
+    userDefinedPatterns = fs.readFileSync(globalExcludeFile).toString().split('\n').filter(e => e.toString().trim() !== '')
+  } catch (e) {
+    debug(e.message)
+  }
+  const allPatterns = [...userDefinedPatterns, ...SYSTEM_EXCLUDE_PATTERNS]
+  return allPatterns
 }

--- a/src/commands/project/watch.ts
+++ b/src/commands/project/watch.ts
@@ -11,7 +11,7 @@
  * governing permissions and limitations under the License.
  */
 
-import { NimBaseCommand, NimLogger, Flags, Credentials, OWOptions, inBrowser, isGithubRef, delay, getExclusionList, isExcluded } from 'nimbella-deployer'
+import { NimBaseCommand, NimLogger, Flags, Credentials, OWOptions, inBrowser, isGithubRef, delay, isExcluded } from 'nimbella-deployer'
 import { ProjectDeploy, processCredentials, doDeploy } from './deploy'
 
 import * as fs from 'fs'

--- a/src/commands/project/watch.ts
+++ b/src/commands/project/watch.ts
@@ -11,7 +11,7 @@
  * governing permissions and limitations under the License.
  */
 
-import { NimBaseCommand, NimLogger, Flags, Credentials, OWOptions, inBrowser, isGithubRef, delay, getExclusionList } from 'nimbella-deployer'
+import { NimBaseCommand, NimLogger, Flags, Credentials, OWOptions, inBrowser, isGithubRef, delay, getExclusionList, isExcluded } from 'nimbella-deployer'
 import { ProjectDeploy, processCredentials, doDeploy } from './deploy'
 
 import * as fs from 'fs'
@@ -90,8 +90,8 @@ function watch(project: string, cmdFlags: Flags, creds: Credentials|undefined, o
   }
   const watch = () => {
     // logger.log("Opening new watcher")
-    watcher = chokidar.watch(project, { ignoreInitial: true, followSymlinks: false, usePolling: false, useFsEvents: false, ignored: getExclusionList(project) })
-    watcher.on('all', async(event, filename) => await fireDeploy(project, filename, cmdFlags, creds, owOptions, logger, reset, watch, event))
+    watcher = chokidar.watch(project, { ignoreInitial: true, followSymlinks: false, usePolling: false, useFsEvents: false })
+    watcher.on('all', async(event, filename) => { if (!isExcluded(path.basename(filename))) { await fireDeploy(project, filename, cmdFlags, creds, owOptions, logger, reset, watch, event) } })
   }
   watch()
 }

--- a/src/commands/project/watch.ts
+++ b/src/commands/project/watch.ts
@@ -90,7 +90,7 @@ function watch(project: string, cmdFlags: Flags, creds: Credentials|undefined, o
   }
   const watch = () => {
     // logger.log("Opening new watcher")
-    watcher = chokidar.watch(project, { ignoreInitial: true, followSymlinks: false, usePolling: false, useFsEvents: false, ignored: getExclusionList() })
+    watcher = chokidar.watch(project, { ignoreInitial: true, followSymlinks: false, usePolling: false, useFsEvents: false, ignored: getExclusionList(project) })
     watcher.on('all', async(event, filename) => await fireDeploy(project, filename, cmdFlags, creds, owOptions, logger, reset, watch, event))
   }
   watch()


### PR DESCRIPTION
The intention is to have a system-defined ignore pattern list and also allow users to specify `ignore` patterns via `.exclude` file in the project root.

WIP:
the  watcher is working (i.e. ignoring the changes in files matching exclude patterns), but the deployer `doDeploy` is still having the error, will have to work on it 
relates to #46 