### PR TITLE
Adding dotnet runtime to runtimes config

### DIFF
--- a/deployer/nimbella-runtimes.json
+++ b/deployer/nimbella-runtimes.json
@@ -291,6 +291,22 @@
           }
         }
       }
+    ],
+    "dotnet": [
+      {
+        "kind": "dotnet:3.1",
+        "default": true,
+        "image": {
+          "name": "action-dotnet-v3.1",
+        },
+        "deprecated": false,
+        "attached": {
+          "attachmentName": "codefile",
+          "attachmentType": "text/plain"
+        },
+        "extensions": {
+        }
+      }
     ]
   },
   "blackboxes": [


### PR DESCRIPTION
Noticed this was missing whilst porting over the tests. Dotnet projects fail to deploy due to missing runtime config.