### PR TITLE
Sequences may include sequences from same project

### DIFF
--- a/tests/sequence/packages/test-sequence/increment.js
+++ b/tests/sequence/packages/test-sequence/increment.js
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function main({ value }) {
+	return { value: parseInt(value, 10) + 1 }
+}

--- a/tests/sequence/project.yml
+++ b/tests/sequence/project.yml
@@ -5,3 +5,17 @@ packages:
       sequence:
         - test-sequence/split
         - test-sequence/sort
+    - name: incrFiveTimes
+      sequence:
+        - test-sequence/incrTwice
+        - test-sequence/incrThreeTimes
+    - name: incrTwice
+      sequence:
+        - test-sequence/increment
+        - test-sequence/increment
+    - name: incrThreeTimes
+      sequence:
+        - test-sequence/increment
+        - test-sequence/increment
+        - test-sequence/increment
+        

--- a/tests/sequence/sushi.json
+++ b/tests/sequence/sushi.json
@@ -1,0 +1,3 @@
+{
+  "payload": "Over-ripe sushi,\nThe Master\nIs full of regret."
+}

--- a/tests/sequence/test.bats
+++ b/tests/sequence/test.bats
@@ -9,7 +9,7 @@ teardown_file() {
 }
 
 @test "invoking sequence runs individual actions" {
-	run $NIM action invoke test-sequence/mySequence --param payload '"Over-ripe sushi,\nThe Master\nIs full of regret."'
+	run $NIM action invoke test-sequence/mySequence --param-file $BATS_TEST_DIRNAME/sushi.json
 	assert_success
 	assert_output '{
   "length": 3,
@@ -18,5 +18,10 @@ teardown_file() {
     "Over-ripe sushi,",
     "The Master"
   ]
+}'
+  run $NIM action invoke test-sequence/incrFiveTimes -p value 0
+	assert_success
+	assert_output '{
+  "value": 5
 }'
 }


### PR DESCRIPTION
This PR covers a loose end from the original work to add sequence support under PR #34 (merged in December, 2020).   It has been a temporary restriction since then that a sequence may not include, as a component, another sequence which is being deployed at the same time.  The change that is provided here removes that restriction.

The existing `sequence` functional test is enhanced to include some sequences that include other sequences.

Incidentally, the PR also tweaks the sequence test to use a parameter file rather than complexly quoted string parameter value in its older logic.   We have recently found shell quoting fragility problems running the test in different environments.