### PR TITLE
Ignore deployer-generated zip files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ productionProjects.json
 /oclif.manifest.json
 /bin/nim
 .nimbella
+__deployer__.zip


### PR DESCRIPTION
I noticed that the repo clone was dirty after running bats tests.