### PR TITLE
Ignore files added during some Nimbella builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,9 @@ productionProjects.json
 /bin/nim
 .nimbella
 __deployer__.zip
+changes.html
+license.html
+thirdparty-licenses.md
+thirdparty-licenses.html
+sensitiveNamespaces.json
+*.bak


### PR DESCRIPTION
Adds entries to `.gitignore` to support NImbella Corp. production builds, which do some tailoring and incorporate some documents (e.g. change log).