### PR TITLE
Fix web-cache test when run on AWS/EKS

### DIFF
--- a/tests/web_cache/test.bats
+++ b/tests/web_cache/test.bats
@@ -11,9 +11,14 @@ teardown_file() {
 }
 
 @test "deploy project web resources with caching on" {
+	APIHOST=$($NIM auth current --apihost)
 	run curl -I $($NIM web get test-web-cache.html --url)
 	assert_success
-	assert_output --regexp "^.*cache-control: *public, *max-age=3600.*$"
+	if [[ "$APIHOST" == *"eks"* ]]; then
+	  [[ "$output" != *"cache-control"* ]]
+	else 
+	  assert_output --regexp "^.*cache-control: *public, *max-age=3600.*$"
+	fi
 }
 
 @test "deploy project web resources with caching off" {


### PR DESCRIPTION
The test for the web cacheing control feature relies on specific header contents that are returned by default when using the Nimbella stack on GCP.   When the stack is run on AWS (EKS), default behavior is different and the test is failing.   This change adjusts for the differences between the two clouds.

An adjustment to how Nimbella declares cacheing behavior for EKS is pending which will make this change effective.   This PR can be merged ahead of that adjustment, since the test on GCP is unaffected and the test is already failing on EKS.

