### PR TITLE
serve-web fixes to make it more useful

### DIFF
--- a/src/commands/project/serve-web.ts
+++ b/src/commands/project/serve-web.ts
@@ -22,7 +22,7 @@ export default class ProjectServeWeb extends NimBaseCommand {
   static flags = {
     namespace: flags.string({ description: 'The namespace to proxy (current namespace if omitted)' }),
     apihost: flags.string({ description: 'API host of the namespace' }),
-    port: flags.integer({ description: 'The port of the web server' }),
+    port: flags.integer({ description: 'The port of the web server (default is 8080)' , default: 8080}),
     ...NimBaseCommand.flags
   }
 

--- a/src/commands/project/serve-web.ts
+++ b/src/commands/project/serve-web.ts
@@ -38,7 +38,7 @@ export default class ProjectServeWeb extends NimBaseCommand {
     const cred = await getCredentials(authPersister)
     const url = new URL(cred.ow.apihost)
     const proxy = `https://${flags.namespace || cred.namespace}-${flags.apihost || url.hostname}`
-    const port = flags.port || 8080
+    const port = flags.port
 
     logger.log(`Proxying API call to ${proxy}`)
 

--- a/src/commands/project/serve-web.ts
+++ b/src/commands/project/serve-web.ts
@@ -31,7 +31,8 @@ export default class ProjectServeWeb extends NimBaseCommand {
   ]
 
   async runCommand(rawArgv: string[], argv: string[], args: any, flags: any, logger: NimLogger): Promise<void> {
-    const webLocation = args.location
+    let webLocation = args.location
+    if (!webLocation.endsWith('/web')) webLocation = join(webLocation, 'web')
     if (!existsSync(webLocation)) { logger.log(`${webLocation} not found`); return }
 
     const cred = await getCredentials(authPersister)


### PR DESCRIPTION
-  disables cache for live reload, bug #110
- removes web suffix to avoid confusing behaviour and unnecessary constraint, bug #111 
- adds port parameter, as you may have a port conflict
