### PR TITLE
Auth env

### DIFF
--- a/src/commands/auth/env.ts
+++ b/src/commands/auth/env.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 - present Nimbella Corp.
+ * Copyright (c) 2021 - present Joshua Auerbach
  *
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy

--- a/src/commands/auth/env.ts
+++ b/src/commands/auth/env.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2019 - present Nimbella Corp.
+ *
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { NimBaseCommand, NimLogger, getCredentials, authPersister } from '@nimbella/nimbella-deployer'
+import { StorageKey } from '@nimbella/storage'
+
+// Theoretically, there is no guarantee that the following constants align with conventions in @nimbella/storage.
+// In practice, IMO, it is safe to assume that these strings are "well-known" and cannot easily change.
+const GCS_PROVIDER = '@nimbella/storage-gcs'
+const S3_PROVIDER = '@nimbella/storage-s3'
+
+export default class AuthEnv extends NimBaseCommand {
+  static description = 'Print storage credentials in the form required in the environment of action runtimes'
+
+  static args = []
+
+  async runCommand(_rawArgv: string[], _argv: string[], _args: any, _flags: any, logger: NimLogger): Promise<void> {
+    const creds = await getCredentials(authPersister).catch(err => logger.handleError('', err))
+    const storage = creds.storageKey as StorageKey
+    if (!storage) {
+      logger.handleError('You do not have storage credentials ... doing nothing')
+    }
+    const namespace = creds.namespace
+    const apiHost = creds.ow.apihost
+    if (!namespace || !apiHost) {
+      logger.handleError('Your current namespace lacks complete information ... doing nothing')
+    }
+    const provider = storage.provider || GCS_PROVIDER
+    if (provider === GCS_PROVIDER) {
+      // The local storage form for this provider differs from what needs to be in the environment (historical).
+      const { credentials, project_id } = storage
+      const { client_email, private_key } = credentials
+      printOutput('__NIM_STORAGE_KEY', JSON.stringify({ client_email, private_key, project_id }), logger)
+    } else if (provider === S3_PROVIDER) {
+      // The S3 provider assumes what's in the environment === what would be stored.
+      printOutput('__NIM_STORAGE_KEY', JSON.stringify(storage), logger)
+    } else {
+      logger.handleError(`No support for storage provider '${provider}'`)
+    }
+    printOutput('__OW_NAMESPACE', namespace, logger)
+    printOutput('__OW_API_HOST', apiHost, logger)
+  }
+}
+
+function printOutput(key: string, value: string, logger: NimLogger) {
+  logger.log(`${key}=${value}`)
+}

--- a/src/commands/auth/env.ts
+++ b/src/commands/auth/env.ts
@@ -11,8 +11,9 @@
  * governing permissions and limitations under the License.
  */
 
-import { NimBaseCommand, NimLogger, getCredentials, authPersister } from '@nimbella/nimbella-deployer'
+import { getCredentials, authPersister } from '@nimbella/nimbella-deployer'
 import { StorageKey } from '@nimbella/storage'
+import { NimBaseCommand, NimLogger } from '../../NimBaseCommand'
 import { flags } from '@oclif/command'
 
 // Theoretically, there is no guarantee that the following constants align with conventions in @nimbella/storage.

--- a/src/commands/auth/env.ts
+++ b/src/commands/auth/env.ts
@@ -13,6 +13,7 @@
 
 import { NimBaseCommand, NimLogger, getCredentials, authPersister } from '@nimbella/nimbella-deployer'
 import { StorageKey } from '@nimbella/storage'
+import { flags } from '@oclif/command'
 
 // Theoretically, there is no guarantee that the following constants align with conventions in @nimbella/storage.
 // In practice, IMO, it is safe to assume that these strings are "well-known" and cannot easily change.
@@ -24,7 +25,12 @@ export default class AuthEnv extends NimBaseCommand {
 
   static args = []
 
-  async runCommand(_rawArgv: string[], _argv: string[], _args: any, _flags: any, logger: NimLogger): Promise<void> {
+  static flags = {
+    quote: flags.boolean({ description: 'Escape and re-quote JSON to survive parsing by a shell' }),
+    ...NimBaseCommand.flags
+  }
+
+  async runCommand(_rawArgv: string[], _argv: string[], _args: any, flags: any, logger: NimLogger): Promise<void> {
     const creds = await getCredentials(authPersister).catch(err => logger.handleError('', err))
     const storage = creds.storageKey as StorageKey
     if (!storage) {
@@ -40,18 +46,26 @@ export default class AuthEnv extends NimBaseCommand {
       // The local storage form for this provider differs from what needs to be in the environment (historical).
       const { credentials, project_id } = storage
       const { client_email, private_key } = credentials
-      printOutput('__NIM_STORAGE_KEY', JSON.stringify({ client_email, private_key, project_id }), logger)
+      printOutput('__NIM_STORAGE_KEY', JSON.stringify({ client_email, private_key, project_id }), logger, flags.quote)
     } else if (provider === S3_PROVIDER) {
       // The S3 provider assumes what's in the environment === what would be stored.
-      printOutput('__NIM_STORAGE_KEY', JSON.stringify(storage), logger)
+      printOutput('__NIM_STORAGE_KEY', JSON.stringify(storage), logger, flags.quote)
     } else {
       logger.handleError(`No support for storage provider '${provider}'`)
     }
-    printOutput('__OW_NAMESPACE', namespace, logger)
-    printOutput('__OW_API_HOST', apiHost, logger)
+    printOutput('__OW_NAMESPACE', namespace, logger, false)
+    printOutput('__OW_API_HOST', apiHost, logger, false)
   }
 }
 
-function printOutput(key: string, value: string, logger: NimLogger) {
+function escapeAndQuote(input: string): string {
+  input = input.replace(/"/g, '\\"')
+  return `"${input}"`
+}
+
+function printOutput(key: string, value: string, logger: NimLogger, quote: boolean) {
+  if (quote) {
+    value = escapeAndQuote(value)
+  }
   logger.log(`${key}=${value}`)
 }


### PR DESCRIPTION
When unit testing code intended to run in the action runtimes (e.g. for Nimbella SDKs) you must simulate the aspects of the process environment that contain necessary credentials and other metadata.  In the case of object store credentials, figuring out what to put in the environment is non-trivial.   The `nim auth env` command provided in this PR helps with this problem (outlined in issue #140).

```
i> nim auth env --help
Print storage credentials in the form required in the environment of action runtimes

USAGE
  $ nim auth:env

OPTIONS
  --quote        Escape and re-quote JSON to survive parsing by a shell
```

The command writes the values of three environment variables (`__OW_NAMESPACE`, `__OW_API_HOST`, and `__NIM_STORAGE_KEY`) to stdout.  Typically, you would redirect to a file or pipe into an appropriate shell command.   The `__NIM_STORAGE_KEY` value is JSON (containing `"` characters) and is neither escaped nor re-quoted by default.   The result is suitable for use by `dotenv` or similar packages (existing for most languages) that load variables directly into the process environment.    If the result must survive parsing by a shell (e.g. when using `source` or `eval` in `bash` or `bats`) then the `--quote` flag should be specified.   The result, in that case, will be correct JSON after (and only after) parsing by a shall.  There will be per-shell and per-testing-framework details to consider to ensure that the result ends up in the process environment of the actual unit test.
