### PR TITLE
Fixing failing integration test in CI pipeline.

### DIFF
--- a/tests/object/test.bats
+++ b/tests/object/test.bats
@@ -3,7 +3,7 @@
 load ../test_setup.bash
 
 # constants
-FILES="$(pwd)/tests/object/test_files/*"
+FILES=$BATS_TEST_DIRNAME/test_files/*
 
 @test "object create" { # object create test
   for f in $FILES
@@ -17,19 +17,18 @@ FILES="$(pwd)/tests/object/test_files/*"
 @test "object get" { # object get test
   for f in $FILES
   do
-    run $NIM object get "$(basename $f)"
+    filename=$(basename $f)
+    run $NIM object get -p $filename
     assert_success
-    if assert_output --partial "done" | grep "Sample text" "$f"
-    then
-      assert true
-    else
-      assert false
-    fi
+    assert_output --partial "done" 
+    assert_output --partial "getting $filename" 
+    # check file contents is correct
+    assert_output --partial "$(cat $f)" 
   done
 }
 
 @test "object list" { # object list test
-  path="$(pwd)/tests/object/test_files"
+  path=$BATS_TEST_DIRNAME/test_files
   list=$(ls -R $path)
 
   run $NIM object list
@@ -40,15 +39,11 @@ FILES="$(pwd)/tests/object/test_files/*"
 @test "object url" { # object url test
   for f in $FILES
   do
-    run $NIM object url "$(basename $f)"
+    filename=$(basename $f)
+    run $NIM object url $filename
     assert_success
-    echo "$output"
-    if curl -s "$output" | grep "Sample text"
-    then
-      assert true
-    else
-      assert false
-  fi
+    run diff $f <(curl -s $output)
+    assert_success
   done
 }
 


### PR DESCRIPTION
Small re-factoring to resolve issue here:
https://github.com/nimbella/nimbella-cli/runs/3253344581?check_suite_focus=true

Whilst fixing the issue - I did a little re-factoring based on my experience writing all the other tests to make them more consistent with the codebase. 

- Use $BATS_TEST_DIRNAME instead of $PWD when running tests as this allows you to run the tests from any directory. 
- Use diff to compare objects retrieved via URLs to check they have the same file contents

@saxena52 Can you have a look over my proposed changes and ensure you're happy with them before I merge?
