### PR TITLE
Fix runtimes init

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1230,9 +1230,9 @@
       "dev": true
     },
     "@nimbella/nimbella-deployer": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-3.0.5.tgz",
-      "integrity": "sha512-H86/LKl+WNxMZt2NI3T8T5eBty9fidoHIe6Zi3PdsXHtt1wAsGF91AJa6cFK/cmt9tilJVqC2uqYZj9GVit1AA==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-3.0.6.tgz",
+      "integrity": "sha512-dzmB/WoZ99W4B7a/b3VaqV1lW0sT/5PpSKr1ZqUPvB/BEEDfGnOIihR8Tndy7egaaJwNFegCty0+zNN84YHmuA==",
       "requires": {
         "@nimbella/sdk": "^1.3.5",
         "@nimbella/storage": "^0.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/nimbella-cli",
-  "version": "1.18.2",
+  "version": "1.18.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/nimbella-cli",
-  "version": "1.18.2",
+  "version": "1.18.3",
   "description": "A comprehensive CLI for the Nimbella stack",
   "main": "lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@adobe/aio-cli-plugin-runtime": "github:nimbella/aio-cli-plugin-runtime#v2021-11-19-1",
     "@adobe/aio-lib-core-config": "^2.0.0",
     "@adobe/aio-lib-runtime": "^2.0.0",
-    "@nimbella/nimbella-deployer": "^3.0.5",
+    "@nimbella/nimbella-deployer": "^3.0.6",
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-autocomplete": "^0.3.0",

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -12,7 +12,7 @@
  */
 
 import { flags } from '@oclif/command'
-import { wskRequest, inBrowser, authPersister, getCredentials, init as initRuntimes } from '@nimbella/nimbella-deployer'
+import { wskRequest, inBrowser, authPersister, getCredentials, initRuntimes } from '@nimbella/nimbella-deployer'
 import { NimBaseCommand, NimLogger, parseAPIHost } from '../NimBaseCommand'
 import { open } from '../ui'
 

--- a/src/commands/project/deploy.ts
+++ b/src/commands/project/deploy.ts
@@ -14,7 +14,7 @@
 import { flags } from '@oclif/command'
 import {
   readAndPrepare, buildProject, deploy, Flags, OWOptions, DeployResponse, Credentials, getCredentialsForNamespace,
-  isGithubRef, authPersister, inBrowser, getGithubAuth, deleteSlice, init as initRuntimes
+  isGithubRef, authPersister, inBrowser, getGithubAuth, deleteSlice, initRuntimes
 } from '@nimbella/nimbella-deployer'
 
 import { NimBaseCommand, NimLogger, NimFeedback, parseAPIHost, disambiguateNamespace, CaptureLogger } from '../../NimBaseCommand'

--- a/src/commands/project/get-metadata.ts
+++ b/src/commands/project/get-metadata.ts
@@ -14,7 +14,7 @@
 import { flags } from '@oclif/command'
 import {
   readProject, Flags, isGithubRef, getGithubAuth, authPersister, inBrowser, makeIncluder,
-  init as initRuntimes, Runtime, getRuntimeForAction
+  initRuntimes, Runtime, getRuntimeForAction
 } from '@nimbella/nimbella-deployer'
 
 import { NimBaseCommand, NimLogger } from '../../NimBaseCommand'


### PR DESCRIPTION
This change incorporates version 3.0.6 of the deployer.   In doing so, it fixes a problem with remote build.

Also bumps the patch release to 1.18.3 so that this can be published and incorporated into runtime builds.