### PR TITLE
Remove reading of runtimes table from 'project get-metadata'

### DIFF
--- a/src/commands/project/get-metadata.ts
+++ b/src/commands/project/get-metadata.ts
@@ -54,23 +54,16 @@ export class ProjectMetadata extends NimBaseCommand {
     this.debug('cmdFlags', cmdFlags)
     // Convert include/exclude flags into an Includer object
     const includer = makeIncluder(flags.include, flags.exclude)
-    // Obtain runtimes table
-    let runtimes: Record<string, Runtime[]>
-    try {
-      runtimes = await initRuntimes()
-    } catch (err) {
-      logger.handleError('Failed to retrieve runtimes.json from platform host.', err)
-    }
 
     // Read the project
-    const result = await readProject(args.project, env, includer, false, undefined, runtimes)
+    const result = await readProject(args.project, env, includer, false, undefined, {})
 
     // Fill in any missing runtimes
     if (result.packages) {
       for (const pkg of result.packages) {
         if (pkg.actions) {
           for (const action of pkg.actions) {
-            action.runtime = await getRuntimeForAction(action, result.reader, runtimes)
+            action.runtime = await getRuntimeForAction(action, result.reader, {})
           }
         }
       }


### PR DESCRIPTION
The 'project get-metadata' command is intended to provide a comprehensive inspection capability for a project.  As such it doesn't really require any credentials.   However, the command was reading the runtimes table.   To do this, it needs an API host.  It was relying on the current API host recorded in the credentials for this.   When this step is removed, the requirement for the credential store to be initialized is eliminated.

It would be _useful_ (should not be required) for this command to have access to a controller in a running deployment so that it can interrogate information that is not otherwise known (for example, the default versions of various languages for which there are runtimes and the default values of the limits).   That may be added in the future, but, at present it seems more important that the command be usable in the widest range of circumstances.