### PR TITLE
Get-metadata to return symbols needed by a project without calling it an error 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1230,9 +1230,9 @@
       "dev": true
     },
     "@nimbella/nimbella-deployer": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-3.0.6.tgz",
-      "integrity": "sha512-dzmB/WoZ99W4B7a/b3VaqV1lW0sT/5PpSKr1ZqUPvB/BEEDfGnOIihR8Tndy7egaaJwNFegCty0+zNN84YHmuA==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-3.0.7.tgz",
+      "integrity": "sha512-xmZS4P5fCN7QkYUp3qR0b3GFZePz7zzODW/rXNtHAcg7MyPi8aAnjnLxMn/Yer2BNBi1HoKnfvcG6PqInpTAXA==",
       "requires": {
         "@nimbella/sdk": "^1.3.5",
         "@nimbella/storage": "^0.0.7",
@@ -2569,9 +2569,9 @@
       "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ=="
     },
     "bignumber.js": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
-      "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
+      "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw=="
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -3968,9 +3968,9 @@
       }
     },
     "google-auth-library": {
-      "version": "7.10.3",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.10.3.tgz",
-      "integrity": "sha512-VBwUCrjR+/p/J4ifSZRXG0XEc3Cm+2xnFrJi3A9DC2GzbCUK5j+R6CfqS7jyu1Hureb1PV53ZXZS1QV9PYUCrw==",
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.11.0.tgz",
+      "integrity": "sha512-3S5jn2quRumvh9F/Ubf7GFrIq71HZ5a6vqosgdIu105kkk0WtSqc2jGCRqtWWOLRS8SX3AHACMOEDxhyWAQIcg==",
       "requires": {
         "arrify": "^2.0.0",
         "base64-js": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@adobe/aio-cli-plugin-runtime": "github:nimbella/aio-cli-plugin-runtime#v2021-11-19-1",
     "@adobe/aio-lib-core-config": "^2.0.0",
     "@adobe/aio-lib-runtime": "^2.0.0",
-    "@nimbella/nimbella-deployer": "^3.0.6",
+    "@nimbella/nimbella-deployer": "^3.0.7",
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-autocomplete": "^0.3.0",

--- a/src/commands/project/get-metadata.ts
+++ b/src/commands/project/get-metadata.ts
@@ -14,7 +14,7 @@
 import { flags } from '@oclif/command'
 import {
   readProject, Flags, isGithubRef, getGithubAuth, authPersister, inBrowser, makeIncluder,
-  initRuntimes, Runtime, getRuntimeForAction
+  getRuntimeForAction, emptyStructure
 } from '@nimbella/nimbella-deployer'
 
 import { NimBaseCommand, NimLogger } from '../../NimBaseCommand'
@@ -56,7 +56,13 @@ export class ProjectMetadata extends NimBaseCommand {
     const includer = makeIncluder(flags.include, flags.exclude)
 
     // Read the project
-    const result = await readProject(args.project, env, includer, false, undefined, {})
+    let result = await readProject(args.project, env, includer, false, undefined, {})
+    const unresolvedVariables = result.unresolvedVariables
+    if (unresolvedVariables) {
+      result = Object.assign(emptyStructure(), { unresolvedVariables })
+    } else if (result.error) {
+      logger.handleError('  ', result.error)
+    }
 
     // Fill in any missing runtimes
     if (result.packages) {


### PR DESCRIPTION
A small fix to the result of get-metadata to make it more useful with projects that require symbols in the environment to complete their definition.