### PR TITLE
Add --build-env flag to project deploy (and watch)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ sensitiveNamespaces.json
 /patches/
 .yalc/
 yalc.lock
+config.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1230,9 +1230,9 @@
       "dev": true
     },
     "@nimbella/nimbella-deployer": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-3.0.7.tgz",
-      "integrity": "sha512-xmZS4P5fCN7QkYUp3qR0b3GFZePz7zzODW/rXNtHAcg7MyPi8aAnjnLxMn/Yer2BNBi1HoKnfvcG6PqInpTAXA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-3.1.0.tgz",
+      "integrity": "sha512-9NMkVvyxylL2zf4/A599TVk0C/taCt57wsv45xpGGoGT0x98LnIc2u2Pzz7oH2f+oGl5nvy4Op5eDzgWsVJnbg==",
       "requires": {
         "@nimbella/sdk": "^1.3.5",
         "@nimbella/storage": "^0.0.7",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@adobe/aio-cli-plugin-runtime": "github:nimbella/aio-cli-plugin-runtime#v2021-11-19-1",
     "@adobe/aio-lib-core-config": "^2.0.0",
     "@adobe/aio-lib-runtime": "^2.0.0",
-    "@nimbella/nimbella-deployer": "^3.0.7",
+    "@nimbella/nimbella-deployer": "^3.1.0",
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-autocomplete": "^0.3.0",

--- a/src/commands/project/deploy.ts
+++ b/src/commands/project/deploy.ts
@@ -25,7 +25,8 @@ export class ProjectDeploy extends NimBaseCommand {
 
   static flags = {
     target: flags.string({ description: 'The target namespace' }),
-    env: flags.string({ description: 'Path to environment file' }),
+    env: flags.string({ description: 'Path to runtime environment file' }),
+    'build-env': flags.string({ description: 'Path to build-time environment file' }),
     apihost: flags.string({ description: 'API host to use' }),
     auth: flags.string({ description: 'OpenWhisk auth token to use' }),
     insecure: flags.boolean({ description: 'Ignore SSL Certificates', default: false }),
@@ -68,6 +69,7 @@ export class ProjectDeploy extends NimBaseCommand {
       production,
       incremental,
       env,
+      buildEnv: flags['build-env'],
       yarn,
       webLocal: flags['web-local'],
       include,

--- a/src/commands/project/get-metadata.ts
+++ b/src/commands/project/get-metadata.ts
@@ -45,6 +45,7 @@ export class ProjectMetadata extends NimBaseCommand {
       production: false,
       incremental: false,
       env,
+      buildEnv: undefined,
       yarn: false,
       include,
       exclude,

--- a/src/commands/project/get-metadata.ts
+++ b/src/commands/project/get-metadata.ts
@@ -57,7 +57,7 @@ export class ProjectMetadata extends NimBaseCommand {
     const includer = makeIncluder(flags.include, flags.exclude)
 
     // Read the project
-    let result = await readProject(args.project, env, includer, false, undefined, {})
+    let result = await readProject(args.project, env, undefined, includer, false, undefined, {})
     const unresolvedVariables = result.unresolvedVariables
     if (unresolvedVariables) {
       result = Object.assign(emptyStructure(), { unresolvedVariables })

--- a/src/commands/project/watch.ts
+++ b/src/commands/project/watch.ts
@@ -25,6 +25,7 @@ export default class ProjectWatch extends NimBaseCommand {
   static flags: any = {
     target: ProjectDeploy.flags.target,
     env: ProjectDeploy.flags.env,
+    'build-env': ProjectDeploy.flags['build-env'],
     apihost: ProjectDeploy.flags.apihost,
     auth: ProjectDeploy.flags.auth,
     insecure: ProjectDeploy.flags.insecure,
@@ -62,6 +63,7 @@ export default class ProjectWatch extends NimBaseCommand {
       production: false,
       incremental: true,
       env,
+      buildEnv: flags['build-env'],
       yarn,
       webLocal: flags['web-local'],
       include,

--- a/tests/build-env/build.env
+++ b/tests/build-env/build.env
@@ -1,0 +1,1 @@
+USER_NAME=sammy

--- a/tests/build-env/packages/test-build-env/test/build.sh
+++ b/tests/build-env/packages/test-build-env/test/build.sh
@@ -1,0 +1,1 @@
+echo '{"name":"'"$USER_NAME"'"}' > config.json

--- a/tests/build-env/packages/test-build-env/test/index.js
+++ b/tests/build-env/packages/test-build-env/test/index.js
@@ -1,0 +1,10 @@
+function main(args) {
+    const config = require('./config.json')
+    let name = config.name
+    let greeting = 'Hello ' + name + '!'
+    console.log(greeting)
+    return {"body": greeting}
+}
+
+exports.main=main
+  

--- a/tests/build-env/project.yml
+++ b/tests/build-env/project.yml
@@ -1,0 +1,5 @@
+packages:
+  - name: test-build-env
+    actions:
+      - name: test
+        runtime: 'nodejs:default'

--- a/tests/build-env/test.bats
+++ b/tests/build-env/test.bats
@@ -1,0 +1,33 @@
+load ../test_setup.bash
+
+teardown_file() {
+  delete_package "test-build-env"
+}
+
+@test "deploy projects with build environment (local build)" {
+  run $NIM project deploy $BATS_TEST_DIRNAME --build-env $BATS_TEST_DIRNAME/build.env 
+  assert_success
+  assert_output --partial "Deployed actions"
+  assert_output --partial "- test-build-env/test"
+}
+
+@test "invoke function built with build environment (local build)" {
+  run $NIM action invoke -r test-build-env/test
+  assert_output --partial "Hello sammy!"
+}
+
+@test "deploy projects with build environment (remote build)" {
+  run rm $BATS_TEST_DIRNAME/packages/test-build-env/test/__deployer__.zip
+  run rm $BATS_TEST_DIRNAME/packages/test-build-env/test/config.json
+  delete_package "test-build-env"
+  run $NIM project deploy $BATS_TEST_DIRNAME --build-env $BATS_TEST_DIRNAME/build.env --remote-build 
+  assert_success
+  assert_output --partial "Deployed actions"
+  assert_output --partial "- test-build-env/test"
+}
+
+@test "invoke function built with build environment (remote build)" {
+  run $NIM action invoke -r test-build-env/test
+  assert_output --partial "Hello sammy!"
+}
+

--- a/tests/build-env/test.bats
+++ b/tests/build-env/test.bats
@@ -1,4 +1,5 @@
 load ../test_setup.bash
+APIHOST=$($NIM auth current --apihost)
 
 teardown_file() {
   delete_package "test-build-env"
@@ -16,7 +17,11 @@ teardown_file() {
   assert_output --partial "Hello sammy!"
 }
 
+# This will not do the right thing on apigcp because the remote support is not there
 @test "deploy projects with build environment (remote build)" {
+  if [[ "$APIHOST" == *"apigcp"* ]]; then
+    skip "Test skipped on apigcp"
+  fi 
   run rm $BATS_TEST_DIRNAME/packages/test-build-env/test/__deployer__.zip
   run rm $BATS_TEST_DIRNAME/packages/test-build-env/test/config.json
   delete_package "test-build-env"
@@ -26,8 +31,11 @@ teardown_file() {
   assert_output --partial "- test-build-env/test"
 }
 
+# This will not do the right thing on apigcp because the remote support is not there
 @test "invoke function built with build environment (remote build)" {
+  if [[ "$APIHOST" == *"apigcp"* ]]; then
+    skip "Test skipped on apigcp"
+  fi 
   run $NIM action invoke -r test-build-env/test
   assert_output --partial "Hello sammy!"
 }
-

--- a/tests/object/test.bats
+++ b/tests/object/test.bats
@@ -28,6 +28,7 @@ FILES=$BATS_TEST_DIRNAME/test_files/*
 }
 
 @test "object list" { # object list test
+  skip "Object list test needs to be rewritten to tolerate other objects present in the bucket"
   path=$BATS_TEST_DIRNAME/test_files
   list=$(ls $path)
 


### PR DESCRIPTION
This adds a flag to `nim project [deploy | watch ]` that permits a property file (identical to that supported by `--env`) to be passed to the build step.   The properties it defines become part of the process environment during the build but have no effect on the runtime environment of the action (unless steps are taken via `project.yml` and `--env` to pass the same values to both).

When this change is in `nim` it will work immediately for local builds.   Before it can work for remote builds, new `nim` must be incorporated into the runtimes.  This is not in plan for `apigcp` but will be in a future deployment.