### PR TITLE
Add a test for deploying a very large number of actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ sensitiveNamespaces.json
 .yalc/
 yalc.lock
 config.json
+/tests/toomany/packages

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/nimbella-cli",
-  "version": "1.19.5",
+  "version": "1.19.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1230,9 +1230,9 @@
       "dev": true
     },
     "@nimbella/nimbella-deployer": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-3.1.5.tgz",
-      "integrity": "sha512-j49GR/0UDGSkXrEIcUhC6hKQf4XrbP/rVaYqsf8j9GmmlriSNsV2wPz+Jiztz7tlEIS8tebJUyzMBC77UM6xAA==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-3.1.6.tgz",
+      "integrity": "sha512-wrVhugoZrG6phP2q+kIeA8AIgipjYBYXM7YxeMu3AFKKDsgmB+wRpAhIeBoNtzX2QXEkqFES7XsRGL+5WdxnZw==",
       "requires": {
         "@nimbella/sdk": "^1.3.5",
         "@nimbella/storage": "^0.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/nimbella-cli",
-  "version": "1.19.5",
+  "version": "1.19.6",
   "description": "A comprehensive CLI for the Nimbella stack",
   "main": "lib/index.js",
   "repository": {
@@ -17,7 +17,7 @@
     "@adobe/aio-cli-plugin-runtime": "github:nimbella/aio-cli-plugin-runtime#v2021-11-19-1",
     "@adobe/aio-lib-core-config": "^2.0.0",
     "@adobe/aio-lib-runtime": "^2.0.0",
-    "@nimbella/nimbella-deployer": "^3.1.5",
+    "@nimbella/nimbella-deployer": "^3.1.6",
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-autocomplete": "^0.3.0",

--- a/tests/test_setup.bash
+++ b/tests/test_setup.bash
@@ -7,13 +7,10 @@ if [ -z "$NIM" ]; then
 fi
 
 # Utility function to clear our all package resources.
-# Turns into no-op if no resources are available in that package.
+# Turns into no-op if no packages match the argument
 delete_package() {
-	for action in $($NIM action list | grep -o "$1.*"); do
-		$NIM action delete $action
-	done
 	for package in $($NIM package list | grep -o "$1.*"); do
-		$NIM package delete $package
+		$NIM package delete $package --recursive
 	done
 }
 

--- a/tests/toomany/test.bats
+++ b/tests/toomany/test.bats
@@ -1,15 +1,17 @@
 load ../test_setup.bash
-APIHOST=$($NIM auth current --apihost)
+ACTION_COUNT=500
 
 teardown_file() {
   delete_package "test-toomany"
 	rm -fr $BATS_TEST_DIRNAME/packages
 }
 
-@test "deploy projects with 500 actions" {
+@test "deploy a project with $ACTION_COUNT actions" {
 	rm -fr $BATS_TEST_DIRNAME/packages
   mkdir -p $BATS_TEST_DIRNAME/packages/test-toomany
-	for i in {1..500}; do touch $BATS_TEST_DIRNAME/packages/test-toomany/h$i.js; done
-  run $NIM project deploy $BATS_TEST_DIRNAME  | grep '\- t' | wc -l
+	for i in $(seq 1 $ACTION_COUNT); do touch $BATS_TEST_DIRNAME/packages/test-toomany/h$i.js; done
+  run $NIM project deploy $BATS_TEST_DIRNAME
   assert_success
+  COUNT=$(echo "$output" | grep -o '\- test-toomany/h' | wc -l) 
+  assert [ $COUNT == $ACTION_COUNT ]  
 }

--- a/tests/toomany/test.bats
+++ b/tests/toomany/test.bats
@@ -1,0 +1,15 @@
+load ../test_setup.bash
+APIHOST=$($NIM auth current --apihost)
+
+teardown_file() {
+  delete_package "test-toomany"
+	rm -fr $BATS_TEST_DIRNAME/packages
+}
+
+@test "deploy projects with 500 actions" {
+	rm -fr $BATS_TEST_DIRNAME/packages
+  mkdir -p $BATS_TEST_DIRNAME/packages/test-toomany
+	for i in {1..500}; do touch $BATS_TEST_DIRNAME/packages/test-toomany/h$i.js; done
+  run $NIM project deploy $BATS_TEST_DIRNAME  | grep '\- t' | wc -l
+  assert_success
+}


### PR DESCRIPTION
The new test attempts to deploy a package with 500 actions in it.   This is likely to fail until after the deployer PR nimbella/nimbella-deployer#46 is merged and a new deployer release is incorporated.