### PR TITLE
Remove update site pointer from installed 'nim'

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "@oclif/config": "^1",
     "@oclif/plugin-autocomplete": "^0.3.0",
     "@oclif/plugin-plugins": "^1.9.0",
-    "@oclif/plugin-update": "^1.3.9",
     "chalk": "^4.1.0",
     "check-node-version": "^4.0.3",
     "chokidar": "^3.4.0",
@@ -85,16 +84,12 @@
     "scope": "nimbella",
     "plugins": [
       "@oclif/plugin-autocomplete",
-      "@oclif/plugin-update",
       "@oclif/plugin-plugins"
     ],
     "macos": {
       "identifier": "com.nimbella.cli"
     },
     "update": {
-      "s3": {
-        "host": "https://apigcp.nimbella.io/downloads/nim"
-      },
       "node": {
         "version": "14.4.0"
       }


### PR DESCRIPTION
The advantages of having an `update` command are lost under the present circumstances (the original update site on `nimbella.io` is no longer hosting new versions).

Planned future packaging of `nim` does not require it to have an update site.

Yet, the presence of an `update` command, an update plugin, and an update site reference in `package.json` conspire to allow users to shoot themselves in the foot by updating to what is actually an older version and making that older version hard to find and delete when using other packaging techniques.

This PR removes the update command and plugin and the update site reference.   Despite this "loss of functionality" I am not going to regard this as a breaking change for versioning purposes 