### PR TITLE
New handling for unresolved vars in get-metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -201,839 +201,839 @@
       }
     },
     "@aws-sdk/abort-controller": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.40.0.tgz",
-      "integrity": "sha512-S7LzLvNuwuf0q7r4q7zqGzxd/W2xYsn8cpZ90MMb3ObolhbkLySrikUJujmXae8k+2/KFCOr+FVC0YLrATSUgQ==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.46.0.tgz",
+      "integrity": "sha512-XrCocRwajh3jkI/Y2PCZjYUZcJfmCa4DYM5nnW2+w4o7ez7vXEQ1j5FCI+/ogJIqfccnmEIlLZGlfzmc6vVbJw==",
       "requires": {
-        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/types": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/chunked-blob-reader": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.37.0.tgz",
-      "integrity": "sha512-uDacnFaczeO962RnVttwAQddS4rgDfI7nfeY8NV6iZkDv5uxGzHTfH4jT7WvPDM1pSMcOMDx8RJ+Tmtsd1VTsA==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.46.0.tgz",
+      "integrity": "sha512-wd2vDT0mjEuOO0IqeWs2CGRWe164I7oeplnkKEC1vG9Bpjww+1u3LoJ1de6plFSLwAoBpqtmIt4koQl5NCyUyQ==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/chunked-blob-reader-native": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.37.0.tgz",
-      "integrity": "sha512-h9OYq6EvDrpb7SKod+Kow+d3aRNFVBYR1a8G8ahEDDQe3AtmA2Smyvni4kt/ABTiKvYdof2//Pq3BL/IUV9n9Q==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.46.0.tgz",
+      "integrity": "sha512-6Oa10XjddRlAooRN5vGI2fBAk5fmLjuR9HHHlcuygnfefXkdmTKaRVSIX0Tdh/rwGz+npOjESaqtKHgMv81gJw==",
       "requires": {
-        "@aws-sdk/util-base64-browser": "3.37.0",
+        "@aws-sdk/util-base64-browser": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/client-s3": {
-      "version": "3.45.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.45.0.tgz",
-      "integrity": "sha512-9JMAdLNWKlqKb3k2mtI0LRrzrfLfqnbShG5e6Im8+Rj+Br5QhtrJ5WIwvT953S+GGumvBzWE28kQcN1/Ve0flw==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.46.0.tgz",
+      "integrity": "sha512-4/p1KQUVRkdhFSh17trEs026SE3fkNkes5zvAD2R385yRJ0i2ImKV2pjzOXDKLcol0X45Ix44KXI3uUE5W8V9A==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.45.0",
-        "@aws-sdk/config-resolver": "3.45.0",
-        "@aws-sdk/credential-provider-node": "3.45.0",
-        "@aws-sdk/eventstream-serde-browser": "3.40.0",
-        "@aws-sdk/eventstream-serde-config-resolver": "3.40.0",
-        "@aws-sdk/eventstream-serde-node": "3.40.0",
-        "@aws-sdk/fetch-http-handler": "3.40.0",
-        "@aws-sdk/hash-blob-browser": "3.40.0",
-        "@aws-sdk/hash-node": "3.40.0",
-        "@aws-sdk/hash-stream-node": "3.45.0",
-        "@aws-sdk/invalid-dependency": "3.40.0",
-        "@aws-sdk/md5-js": "3.40.0",
-        "@aws-sdk/middleware-apply-body-checksum": "3.40.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.41.0",
-        "@aws-sdk/middleware-content-length": "3.40.0",
-        "@aws-sdk/middleware-expect-continue": "3.40.0",
-        "@aws-sdk/middleware-host-header": "3.40.0",
-        "@aws-sdk/middleware-location-constraint": "3.40.0",
-        "@aws-sdk/middleware-logger": "3.40.0",
-        "@aws-sdk/middleware-retry": "3.40.0",
-        "@aws-sdk/middleware-sdk-s3": "3.45.0",
-        "@aws-sdk/middleware-serde": "3.40.0",
-        "@aws-sdk/middleware-signing": "3.45.0",
-        "@aws-sdk/middleware-ssec": "3.40.0",
-        "@aws-sdk/middleware-stack": "3.40.0",
-        "@aws-sdk/middleware-user-agent": "3.40.0",
-        "@aws-sdk/node-config-provider": "3.40.0",
-        "@aws-sdk/node-http-handler": "3.40.0",
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/smithy-client": "3.41.0",
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/url-parser": "3.40.0",
-        "@aws-sdk/util-base64-browser": "3.37.0",
-        "@aws-sdk/util-base64-node": "3.37.0",
-        "@aws-sdk/util-body-length-browser": "3.37.0",
-        "@aws-sdk/util-body-length-node": "3.37.0",
-        "@aws-sdk/util-user-agent-browser": "3.40.0",
-        "@aws-sdk/util-user-agent-node": "3.40.0",
-        "@aws-sdk/util-utf8-browser": "3.37.0",
-        "@aws-sdk/util-utf8-node": "3.37.0",
-        "@aws-sdk/util-waiter": "3.40.0",
-        "@aws-sdk/xml-builder": "3.37.0",
+        "@aws-sdk/client-sts": "3.46.0",
+        "@aws-sdk/config-resolver": "3.46.0",
+        "@aws-sdk/credential-provider-node": "3.46.0",
+        "@aws-sdk/eventstream-serde-browser": "3.46.0",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.46.0",
+        "@aws-sdk/eventstream-serde-node": "3.46.0",
+        "@aws-sdk/fetch-http-handler": "3.46.0",
+        "@aws-sdk/hash-blob-browser": "3.46.0",
+        "@aws-sdk/hash-node": "3.46.0",
+        "@aws-sdk/hash-stream-node": "3.46.0",
+        "@aws-sdk/invalid-dependency": "3.46.0",
+        "@aws-sdk/md5-js": "3.46.0",
+        "@aws-sdk/middleware-apply-body-checksum": "3.46.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.46.0",
+        "@aws-sdk/middleware-content-length": "3.46.0",
+        "@aws-sdk/middleware-expect-continue": "3.46.0",
+        "@aws-sdk/middleware-host-header": "3.46.0",
+        "@aws-sdk/middleware-location-constraint": "3.46.0",
+        "@aws-sdk/middleware-logger": "3.46.0",
+        "@aws-sdk/middleware-retry": "3.46.0",
+        "@aws-sdk/middleware-sdk-s3": "3.46.0",
+        "@aws-sdk/middleware-serde": "3.46.0",
+        "@aws-sdk/middleware-signing": "3.46.0",
+        "@aws-sdk/middleware-ssec": "3.46.0",
+        "@aws-sdk/middleware-stack": "3.46.0",
+        "@aws-sdk/middleware-user-agent": "3.46.0",
+        "@aws-sdk/node-config-provider": "3.46.0",
+        "@aws-sdk/node-http-handler": "3.46.0",
+        "@aws-sdk/protocol-http": "3.46.0",
+        "@aws-sdk/smithy-client": "3.46.0",
+        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/url-parser": "3.46.0",
+        "@aws-sdk/util-base64-browser": "3.46.0",
+        "@aws-sdk/util-base64-node": "3.46.0",
+        "@aws-sdk/util-body-length-browser": "3.46.0",
+        "@aws-sdk/util-body-length-node": "3.46.0",
+        "@aws-sdk/util-user-agent-browser": "3.46.0",
+        "@aws-sdk/util-user-agent-node": "3.46.0",
+        "@aws-sdk/util-utf8-browser": "3.46.0",
+        "@aws-sdk/util-utf8-node": "3.46.0",
+        "@aws-sdk/util-waiter": "3.46.0",
+        "@aws-sdk/xml-builder": "3.46.0",
         "entities": "2.2.0",
         "fast-xml-parser": "3.19.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.45.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.45.0.tgz",
-      "integrity": "sha512-MfsKg4Wq5KvuGEg+M7kYfl6B3TRhxKeL01+5wtxhYbiLqxzr18mfO8PnBAasXMmYCmEQsSGmFepD7GLOld9uHA==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.46.0.tgz",
+      "integrity": "sha512-n+dHT9azUW4pFA7a98gV/qFYdNwoMQ/4Y4tvPE28s9CKx8O0OIDlOwLPrhSBETCuRJNfnug1vNnFIzvOapfCkg==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.45.0",
-        "@aws-sdk/fetch-http-handler": "3.40.0",
-        "@aws-sdk/hash-node": "3.40.0",
-        "@aws-sdk/invalid-dependency": "3.40.0",
-        "@aws-sdk/middleware-content-length": "3.40.0",
-        "@aws-sdk/middleware-host-header": "3.40.0",
-        "@aws-sdk/middleware-logger": "3.40.0",
-        "@aws-sdk/middleware-retry": "3.40.0",
-        "@aws-sdk/middleware-serde": "3.40.0",
-        "@aws-sdk/middleware-stack": "3.40.0",
-        "@aws-sdk/middleware-user-agent": "3.40.0",
-        "@aws-sdk/node-config-provider": "3.40.0",
-        "@aws-sdk/node-http-handler": "3.40.0",
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/smithy-client": "3.41.0",
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/url-parser": "3.40.0",
-        "@aws-sdk/util-base64-browser": "3.37.0",
-        "@aws-sdk/util-base64-node": "3.37.0",
-        "@aws-sdk/util-body-length-browser": "3.37.0",
-        "@aws-sdk/util-body-length-node": "3.37.0",
-        "@aws-sdk/util-user-agent-browser": "3.40.0",
-        "@aws-sdk/util-user-agent-node": "3.40.0",
-        "@aws-sdk/util-utf8-browser": "3.37.0",
-        "@aws-sdk/util-utf8-node": "3.37.0",
+        "@aws-sdk/config-resolver": "3.46.0",
+        "@aws-sdk/fetch-http-handler": "3.46.0",
+        "@aws-sdk/hash-node": "3.46.0",
+        "@aws-sdk/invalid-dependency": "3.46.0",
+        "@aws-sdk/middleware-content-length": "3.46.0",
+        "@aws-sdk/middleware-host-header": "3.46.0",
+        "@aws-sdk/middleware-logger": "3.46.0",
+        "@aws-sdk/middleware-retry": "3.46.0",
+        "@aws-sdk/middleware-serde": "3.46.0",
+        "@aws-sdk/middleware-stack": "3.46.0",
+        "@aws-sdk/middleware-user-agent": "3.46.0",
+        "@aws-sdk/node-config-provider": "3.46.0",
+        "@aws-sdk/node-http-handler": "3.46.0",
+        "@aws-sdk/protocol-http": "3.46.0",
+        "@aws-sdk/smithy-client": "3.46.0",
+        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/url-parser": "3.46.0",
+        "@aws-sdk/util-base64-browser": "3.46.0",
+        "@aws-sdk/util-base64-node": "3.46.0",
+        "@aws-sdk/util-body-length-browser": "3.46.0",
+        "@aws-sdk/util-body-length-node": "3.46.0",
+        "@aws-sdk/util-user-agent-browser": "3.46.0",
+        "@aws-sdk/util-user-agent-node": "3.46.0",
+        "@aws-sdk/util-utf8-browser": "3.46.0",
+        "@aws-sdk/util-utf8-node": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.45.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.45.0.tgz",
-      "integrity": "sha512-D+VGhAg+1i7/WQhfkLn7nWHR+Uyp7FPVAQ/N2MBQvZxGbSSb2agU9DN2FnxeFljOEcGJ7NdJ9YSZCFlJo0bLWA==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.46.0.tgz",
+      "integrity": "sha512-iZqMLOYZ0/x19towcaqdL6zEfFRSPQKEZjbBKujeHlWNEi0ldlCt3a5R3V0nntoaPoa6bopUxRYj3VTLGD43Sg==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.45.0",
-        "@aws-sdk/credential-provider-node": "3.45.0",
-        "@aws-sdk/fetch-http-handler": "3.40.0",
-        "@aws-sdk/hash-node": "3.40.0",
-        "@aws-sdk/invalid-dependency": "3.40.0",
-        "@aws-sdk/middleware-content-length": "3.40.0",
-        "@aws-sdk/middleware-host-header": "3.40.0",
-        "@aws-sdk/middleware-logger": "3.40.0",
-        "@aws-sdk/middleware-retry": "3.40.0",
-        "@aws-sdk/middleware-sdk-sts": "3.45.0",
-        "@aws-sdk/middleware-serde": "3.40.0",
-        "@aws-sdk/middleware-signing": "3.45.0",
-        "@aws-sdk/middleware-stack": "3.40.0",
-        "@aws-sdk/middleware-user-agent": "3.40.0",
-        "@aws-sdk/node-config-provider": "3.40.0",
-        "@aws-sdk/node-http-handler": "3.40.0",
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/smithy-client": "3.41.0",
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/url-parser": "3.40.0",
-        "@aws-sdk/util-base64-browser": "3.37.0",
-        "@aws-sdk/util-base64-node": "3.37.0",
-        "@aws-sdk/util-body-length-browser": "3.37.0",
-        "@aws-sdk/util-body-length-node": "3.37.0",
-        "@aws-sdk/util-user-agent-browser": "3.40.0",
-        "@aws-sdk/util-user-agent-node": "3.40.0",
-        "@aws-sdk/util-utf8-browser": "3.37.0",
-        "@aws-sdk/util-utf8-node": "3.37.0",
+        "@aws-sdk/config-resolver": "3.46.0",
+        "@aws-sdk/credential-provider-node": "3.46.0",
+        "@aws-sdk/fetch-http-handler": "3.46.0",
+        "@aws-sdk/hash-node": "3.46.0",
+        "@aws-sdk/invalid-dependency": "3.46.0",
+        "@aws-sdk/middleware-content-length": "3.46.0",
+        "@aws-sdk/middleware-host-header": "3.46.0",
+        "@aws-sdk/middleware-logger": "3.46.0",
+        "@aws-sdk/middleware-retry": "3.46.0",
+        "@aws-sdk/middleware-sdk-sts": "3.46.0",
+        "@aws-sdk/middleware-serde": "3.46.0",
+        "@aws-sdk/middleware-signing": "3.46.0",
+        "@aws-sdk/middleware-stack": "3.46.0",
+        "@aws-sdk/middleware-user-agent": "3.46.0",
+        "@aws-sdk/node-config-provider": "3.46.0",
+        "@aws-sdk/node-http-handler": "3.46.0",
+        "@aws-sdk/protocol-http": "3.46.0",
+        "@aws-sdk/smithy-client": "3.46.0",
+        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/url-parser": "3.46.0",
+        "@aws-sdk/util-base64-browser": "3.46.0",
+        "@aws-sdk/util-base64-node": "3.46.0",
+        "@aws-sdk/util-body-length-browser": "3.46.0",
+        "@aws-sdk/util-body-length-node": "3.46.0",
+        "@aws-sdk/util-user-agent-browser": "3.46.0",
+        "@aws-sdk/util-user-agent-node": "3.46.0",
+        "@aws-sdk/util-utf8-browser": "3.46.0",
+        "@aws-sdk/util-utf8-node": "3.46.0",
         "entities": "2.2.0",
         "fast-xml-parser": "3.19.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/config-resolver": {
-      "version": "3.45.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.45.0.tgz",
-      "integrity": "sha512-pk+9jWQGvga2jr4aiB/KR1vAI0vPngvo9HqBbKebbJzaBhpA/RwGVWB1ZJch93oG8DBeyKZ0md9eOJRU1BkTIQ==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.46.0.tgz",
+      "integrity": "sha512-R7YGDhvVE1VIS7uyjG3rZE1nrRu/+YVBq/pPlq5f4Tis3EoUooPfr5yYOVAuZI1CGsgycbCi6jnaqLGIfxUFmQ==",
       "requires": {
-        "@aws-sdk/signature-v4": "3.45.0",
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/util-config-provider": "3.40.0",
+        "@aws-sdk/signature-v4": "3.46.0",
+        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/util-config-provider": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/credential-provider-env": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.40.0.tgz",
-      "integrity": "sha512-qHZdf2vxhzZkSygjw2I4SEYFL2dMZxxYvO4QlkqQouKY81OVxs/j69oiNCjPasQzGz5jaZZKI8xEAIfkSyr1lg==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.46.0.tgz",
+      "integrity": "sha512-dBCyVBJ1nVi+lvM1jV6LFw8FpGjdeCglLMTmZUxJLBMh/Lp+GWtnGxd7u38WnH5gxKC4xLnYj9zP1t0ha1tGzQ==",
       "requires": {
-        "@aws-sdk/property-provider": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/property-provider": "3.46.0",
+        "@aws-sdk/types": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/credential-provider-imds": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.40.0.tgz",
-      "integrity": "sha512-Ty/wVa+BQrCFrP06AGl5S1CeLifDt68YrlYXUnkRn603SX4DvxBgVO7XFeDH58G8ziDCiqxfmVl4yjbncPPeSw==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.46.0.tgz",
+      "integrity": "sha512-nQidNDq6mjas/wFOi9XvHkvNmzM/XdSB/eRh6CH+wQeb8RjAlGm2Ivg0mpz/iIxjPXDIduW8aI/gFU3+3um6CQ==",
       "requires": {
-        "@aws-sdk/node-config-provider": "3.40.0",
-        "@aws-sdk/property-provider": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/url-parser": "3.40.0",
+        "@aws-sdk/node-config-provider": "3.46.0",
+        "@aws-sdk/property-provider": "3.46.0",
+        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/url-parser": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.45.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.45.0.tgz",
-      "integrity": "sha512-lfYh8LVW33de01zzfqs6H+4xr20l+++QtvWG8PwKzEAY/71s344ybrOw7KiVUkCDLLbj3SWEmsMJFvBcrvifbA==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.46.0.tgz",
+      "integrity": "sha512-D+3YLWzCaFUUcbLHAsJIoaI8AhoSpIl3c0a3spVN64f+V1XtwunbJO6VXsIF78RLe0kTP7IA/Rey86ydQVeqcw==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.40.0",
-        "@aws-sdk/credential-provider-imds": "3.40.0",
-        "@aws-sdk/credential-provider-sso": "3.45.0",
-        "@aws-sdk/credential-provider-web-identity": "3.41.0",
-        "@aws-sdk/property-provider": "3.40.0",
-        "@aws-sdk/shared-ini-file-loader": "3.37.0",
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/util-credentials": "3.37.0",
+        "@aws-sdk/credential-provider-env": "3.46.0",
+        "@aws-sdk/credential-provider-imds": "3.46.0",
+        "@aws-sdk/credential-provider-sso": "3.46.0",
+        "@aws-sdk/credential-provider-web-identity": "3.46.0",
+        "@aws-sdk/property-provider": "3.46.0",
+        "@aws-sdk/shared-ini-file-loader": "3.46.0",
+        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/util-credentials": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.45.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.45.0.tgz",
-      "integrity": "sha512-ZNqo0JlA7S4k1bAB+Xb8A3KsmNPWVFMmoY3NC25dgXU4xQLVxy0MucQggnfCqRjvshwI4OEdDQsRgl69n/XErQ==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.46.0.tgz",
+      "integrity": "sha512-TrlGFBpIEHy7SnFOL8bE4IUC1Albxg1aSYgU92dzjGe1HhUSOzFABZhqwzfoo/xTCuS/DnA+2aTVD+hRR9t1Mw==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.40.0",
-        "@aws-sdk/credential-provider-imds": "3.40.0",
-        "@aws-sdk/credential-provider-ini": "3.45.0",
-        "@aws-sdk/credential-provider-process": "3.40.0",
-        "@aws-sdk/credential-provider-sso": "3.45.0",
-        "@aws-sdk/credential-provider-web-identity": "3.41.0",
-        "@aws-sdk/property-provider": "3.40.0",
-        "@aws-sdk/shared-ini-file-loader": "3.37.0",
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/util-credentials": "3.37.0",
+        "@aws-sdk/credential-provider-env": "3.46.0",
+        "@aws-sdk/credential-provider-imds": "3.46.0",
+        "@aws-sdk/credential-provider-ini": "3.46.0",
+        "@aws-sdk/credential-provider-process": "3.46.0",
+        "@aws-sdk/credential-provider-sso": "3.46.0",
+        "@aws-sdk/credential-provider-web-identity": "3.46.0",
+        "@aws-sdk/property-provider": "3.46.0",
+        "@aws-sdk/shared-ini-file-loader": "3.46.0",
+        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/util-credentials": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/credential-provider-process": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.40.0.tgz",
-      "integrity": "sha512-qsaNCDesW2GasDbzpeOA371gxugi05JWxt3EKonLbUfkGKBK7kmmL6EgLIxZuNm2/Ve4RS07PKp8yBGm4xIx9w==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.46.0.tgz",
+      "integrity": "sha512-uW2+NgsqAJmQDQ6Y5t+U6E3LjLTEc06FCtJZIdYmfSGnsZoVH26DDIDg92G1ptFF8AzV26aypF2kjiRVRhIwDQ==",
       "requires": {
-        "@aws-sdk/property-provider": "3.40.0",
-        "@aws-sdk/shared-ini-file-loader": "3.37.0",
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/util-credentials": "3.37.0",
+        "@aws-sdk/property-provider": "3.46.0",
+        "@aws-sdk/shared-ini-file-loader": "3.46.0",
+        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/util-credentials": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.45.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.45.0.tgz",
-      "integrity": "sha512-FBMn+QA6rI74A90ieQtCJckbKPBxNn4mgR9rzWyi/R6o5gVuu99yJGL03NXtWtm5N4x/1SygBtezY/XL5UU0Mg==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.46.0.tgz",
+      "integrity": "sha512-y3zv6FtaEu1cjtun6vQ1S/2aya70cPjCcoQhSrsH9TDYXp/ZRk4PN6xdVGGpkZX2kZhowGU5DvhOGK48IqrNZg==",
       "requires": {
-        "@aws-sdk/client-sso": "3.45.0",
-        "@aws-sdk/property-provider": "3.40.0",
-        "@aws-sdk/shared-ini-file-loader": "3.37.0",
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/util-credentials": "3.37.0",
+        "@aws-sdk/client-sso": "3.46.0",
+        "@aws-sdk/property-provider": "3.46.0",
+        "@aws-sdk/shared-ini-file-loader": "3.46.0",
+        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/util-credentials": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/credential-provider-web-identity": {
-      "version": "3.41.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.41.0.tgz",
-      "integrity": "sha512-VqvVoEh9C8xTXl4stKyJC5IKQhS8g1Gi5k6B9HPHLIxFRRfKxkE73DT4pMN6npnus7o0yi0MTFGQFQGYSrFO2g==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.46.0.tgz",
+      "integrity": "sha512-VUNTS9HjwLRmS2OQ+i4tqVJBUpk/DjIT0sWUDnKBcC6UCyGOkVmBVisCvUHpwyCLCgYbCvTab1SfrJ8dZsN83w==",
       "requires": {
-        "@aws-sdk/property-provider": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/property-provider": "3.46.0",
+        "@aws-sdk/types": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/eventstream-marshaller": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-marshaller/-/eventstream-marshaller-3.40.0.tgz",
-      "integrity": "sha512-zHGchfkG3B9M8OOKRpByeS5g1/15YQ0+QQHwxQRtm/CPtKBAIAsCZRQaCNBLu9uQMtBBKj5JsDUcjirhGeSvIg==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-marshaller/-/eventstream-marshaller-3.46.0.tgz",
+      "integrity": "sha512-R6dDgiiAUDxss0rYpkOmSGQAtZNM66WNoR6UYWdEGU4rrapP5oT8z2N2cwv3ZuYsPESwXRu0D3S4jUSoIcxdqw==",
       "requires": {
         "@aws-crypto/crc32": "2.0.0",
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/util-hex-encoding": "3.37.0",
+        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/util-hex-encoding": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/eventstream-serde-browser": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.40.0.tgz",
-      "integrity": "sha512-V0AXAfSkhY0hgxDJ0cNA+r42kL8295U7UTCp2Q2fvCaob3wKWh+54KZ2L4IOYTlK3yNzXJ5V6PP1zUuRlsUTew==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.46.0.tgz",
+      "integrity": "sha512-c/pt2uH6n5rkaTlML0SHEepK6+L9TWgxFNy2+zAtWaHBCUyhTyv49H5jFaZOGWx4HkL+GzQqYfd85xHp362kTw==",
       "requires": {
-        "@aws-sdk/eventstream-marshaller": "3.40.0",
-        "@aws-sdk/eventstream-serde-universal": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/eventstream-marshaller": "3.46.0",
+        "@aws-sdk/eventstream-serde-universal": "3.46.0",
+        "@aws-sdk/types": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/eventstream-serde-config-resolver": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.40.0.tgz",
-      "integrity": "sha512-GgGiJBsQ1/SBTpRM/wCdFBCMo1Nybvy46bNVkH1ujCdp8UTLc5PozzNpH+15V2IQbc9sPDYffMab6HSFjDp5vw==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.46.0.tgz",
+      "integrity": "sha512-I9EcaP331MhJ9jCdKoJRB3hLzRS1+k/Z0qNl6Q/w3QiRvV2ujFcUkFOC4Po/ZYwqX00t4G1RVRlLYpNEGpLwDQ==",
       "requires": {
-        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/types": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/eventstream-serde-node": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.40.0.tgz",
-      "integrity": "sha512-CnzX/JZGvhWlg+ooIPVZ78T+5wIm5Ld1BD7jwhlptJa8IjTMvkc8Nh4pAhc7T0ZScy4zZa/oTkqeVYCOVCyd1Q==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.46.0.tgz",
+      "integrity": "sha512-gU6GrZPYAbhUXvWQg/TZywpefaJHQ7Q4HskJGJWbwXEvsIGabpoY2NIbjiHfFsBxY3/6p0fxeQDoGQHgsGzw3w==",
       "requires": {
-        "@aws-sdk/eventstream-marshaller": "3.40.0",
-        "@aws-sdk/eventstream-serde-universal": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/eventstream-marshaller": "3.46.0",
+        "@aws-sdk/eventstream-serde-universal": "3.46.0",
+        "@aws-sdk/types": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/eventstream-serde-universal": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.40.0.tgz",
-      "integrity": "sha512-rkHwVMyZJMhp9iBixkuaAGQNer/DPxZ9kxDDtE+LuAMhepTYQ8c4lUW0QQhYbNMWf48QKD1G4FV3JXIj9JfP9A==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.46.0.tgz",
+      "integrity": "sha512-sCwmAeotYun6q3o1KHeF7nYdHu78tOdjRSSoPCT10Ba+3ZzYaHNGWP+kpw6v1JTIkxmQIIqe4EMwtJ4xcOv0hw==",
       "requires": {
-        "@aws-sdk/eventstream-marshaller": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/eventstream-marshaller": "3.46.0",
+        "@aws-sdk/types": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/fetch-http-handler": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.40.0.tgz",
-      "integrity": "sha512-w1HiZromoU+/bbEo89uO81l6UO/M+c2uOMnXntZqe6t3ZHUUUo3AbvhKh0QGVFqRQa+Oi0+95KqWmTHa72/9Iw==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.46.0.tgz",
+      "integrity": "sha512-uOfdwbUCG+2LQ4iMkxD/izlzjnIrB5P5HtH7L5w1EFIsdxDXeFnnql0FaEcOvaEEg2rs9z0t+oLwMJZnNNtqAg==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/querystring-builder": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/util-base64-browser": "3.37.0",
+        "@aws-sdk/protocol-http": "3.46.0",
+        "@aws-sdk/querystring-builder": "3.46.0",
+        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/util-base64-browser": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/hash-blob-browser": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.40.0.tgz",
-      "integrity": "sha512-l8xyprVVKKH+720VrQ677X6VkvHttDXB4MxkMuxhSvwYBQwsRzP2Wppo7xIAtWGoS+oqlLmD4LCbHdhFRcN5yA==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.46.0.tgz",
+      "integrity": "sha512-kCLzwH84gIQf6UW5WjgHKcMUfMYrNvB7w9v1GM5Hj4BITNpHbEo51EBKOpOzXfzy1J/kNpmET1TQENKK6a+nmw==",
       "requires": {
-        "@aws-sdk/chunked-blob-reader": "3.37.0",
-        "@aws-sdk/chunked-blob-reader-native": "3.37.0",
-        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/chunked-blob-reader": "3.46.0",
+        "@aws-sdk/chunked-blob-reader-native": "3.46.0",
+        "@aws-sdk/types": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/hash-node": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.40.0.tgz",
-      "integrity": "sha512-yOXXK85DdGDktdnQtXgMdaVKii4wtMjEhJ1mrvx2A9nMFNaPhxvERkVVIUKSWlJRa9ZujOw5jWOx8d2R51/Kjg==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.46.0.tgz",
+      "integrity": "sha512-rABF9k5uSJdqmwBeYnu+2+iWEmPNVsoBy9bwLvEmGfh557wAwh3dL5IDf+NiIFrd8GTOF/2HV1477XXBl15C0g==",
       "requires": {
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/util-buffer-from": "3.37.0",
+        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/util-buffer-from": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/hash-stream-node": {
-      "version": "3.45.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.45.0.tgz",
-      "integrity": "sha512-gZiH4wgYvsLxyMnMvuF3UmOl9KkFTrixIatlFdYG6eLCDgP2oOkXeW007Yu6BQxchsTUC7WUZ971R3T1DtpJlQ==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.46.0.tgz",
+      "integrity": "sha512-Q67LTIJG1Pq55uFKV2glQT3PN3nxit2x86BM0pUPKJrTVP+rPDgSC9jWaSXZwlj2EmwGrtz1eS8929zKCUBsOg==",
       "requires": {
-        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/types": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/invalid-dependency": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.40.0.tgz",
-      "integrity": "sha512-axIWtDwCBDDqEgAJipX1FB1ZNpWYXquVwKDMo+7G+ftPBZ4FEq4M1ELhXJL3hhNJ9ZmCQzv+4F6Wnt8dwuzUaQ==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.46.0.tgz",
+      "integrity": "sha512-KumWtDstAKpKRQbHA95AeHpBNtxCXHVbUk+nFAiXcBP281yEalUbyK0W5Q2bDl26L3z6zHodg3OJllHYavJKMg==",
       "requires": {
-        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/types": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/is-array-buffer": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.37.0.tgz",
-      "integrity": "sha512-XLjA/a6AuGnCvcJZLsMTy2jxF2upgGhqCCkoIJgLlzzXHSihur13KcmPvW/zcaGnCRj0SvKWXiJHl4vDlW75VQ==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.46.0.tgz",
+      "integrity": "sha512-HcQtJgZDQgo7ivD79GF82pTf+zYGjsgzKG7lkUBEetSfkV0W8h6XfhN6DmuYQuCcu1Pt9IkN7haYNPiPdfDhvg==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/md5-js": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.40.0.tgz",
-      "integrity": "sha512-P1tzEljMD/MkjSc00TkVBYvfaVv/7S+04YEwE7tpu/jtxWxMHnk3CMKqq/F2iMhY83DRoqoYy+YqnaF4Bzr1uA==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.46.0.tgz",
+      "integrity": "sha512-2Ylg5fzOZpLGB47zR+ntroaZrMQp/E/nt+bqULqwQYVnA6+EN6+VDD4dKF3niFVIZcY1btcnMbshUJ4MnNjhcg==",
       "requires": {
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/util-utf8-browser": "3.37.0",
-        "@aws-sdk/util-utf8-node": "3.37.0",
+        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/util-utf8-browser": "3.46.0",
+        "@aws-sdk/util-utf8-node": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-apply-body-checksum": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-apply-body-checksum/-/middleware-apply-body-checksum-3.40.0.tgz",
-      "integrity": "sha512-gNSFlFu/O8cxAM0X64OwiLLN/NPXvK3FsAIJRsfhIW+dX0bEq4lsGPsdU8Tx+9eenaj/Z01uqgWZ6Izar8zVvQ==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-apply-body-checksum/-/middleware-apply-body-checksum-3.46.0.tgz",
+      "integrity": "sha512-PAss3dfIKmdpDyGNO6SaQLZvN8nytWGyjG/C+oPB8dW0kPJEf4wIMUAZbW3bqppwoe+bqAWt58v+Mw6XK4DZxw==",
       "requires": {
-        "@aws-sdk/is-array-buffer": "3.37.0",
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/is-array-buffer": "3.46.0",
+        "@aws-sdk/protocol-http": "3.46.0",
+        "@aws-sdk/types": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.41.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.41.0.tgz",
-      "integrity": "sha512-4A0kWHH2qemd4P7CZKS7XB6qtSUP2xMJ7Dn/llxYgvadR0mKEfGPeYPhAss/k7T1JGv+kSTIV30RwUXwdXgE/A==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.46.0.tgz",
+      "integrity": "sha512-o5ryy1xMSokFI9tJY3zsX5pSk4/Wl21Jnz+JIiwcRinIZF3NvFz3b4eKHQn4FpNX5PvBrSHCk46drMtXB2oNyw==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/util-arn-parser": "3.37.0",
-        "@aws-sdk/util-config-provider": "3.40.0",
+        "@aws-sdk/protocol-http": "3.46.0",
+        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/util-arn-parser": "3.46.0",
+        "@aws-sdk/util-config-provider": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-content-length": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.40.0.tgz",
-      "integrity": "sha512-sybAJb8v7I/vvL08R3+TI/XDAg9gybQTZ2treC24Ap4+jAOz4QBTHJPMKaUlEeFlMUcq4rj6/u2897ebYH6opw==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.46.0.tgz",
+      "integrity": "sha512-Vf17vKAZ9n2ZlkMoHmCXMHAJegw3djC8qxe2sGdHSGyozfJNpA77ec32ldLvBtQ82LPmSaqdhcbP0/oYCalnzA==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/protocol-http": "3.46.0",
+        "@aws-sdk/types": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-expect-continue": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.40.0.tgz",
-      "integrity": "sha512-FY6vT0u1ptDZ2bBj1yG/Iyk6HZB7U9fbrpeZNPYzgq8HJxBcTgfLwtB3VLobyhThQm9X2a7R2YZrwtArW8yQfQ==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.46.0.tgz",
+      "integrity": "sha512-AGYg2B2WJJlj/VfaqGcxS5hRKkyGo4kVTeEYxxoVpg1FziaoAwcUEehAZSfHL9bVffXr+pIL7VFz5GppLWALYg==",
       "requires": {
-        "@aws-sdk/middleware-header-default": "3.40.0",
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/middleware-header-default": "3.46.0",
+        "@aws-sdk/protocol-http": "3.46.0",
+        "@aws-sdk/types": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-header-default": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-3.40.0.tgz",
-      "integrity": "sha512-eXQ13x/AivPZKoG8/akp9g5xdNHuKftl83GMuk9K6tt4+eAa22TdxiFu4R0UVlKAvo2feqxFrNs5DhhhBeAQWA==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-3.46.0.tgz",
+      "integrity": "sha512-HutbKluZuk4hm2RT0lE2XmO8UN8Fs8jQ+A5u3TNYxJeX4NpatQ5Nw7b3GwTe9SVOQ0l1iMjtrYvM8gfbjH00dQ==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/protocol-http": "3.46.0",
+        "@aws-sdk/types": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-host-header": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.40.0.tgz",
-      "integrity": "sha512-/wocR7JFOLM7/+BQM1DgAd6KCFYcdxYu1P7AhI451GlVNuYa5f89zh7p0gt3SRC6monI5lXgpL7RudhDm8fTrA==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.46.0.tgz",
+      "integrity": "sha512-I+WsUzpyzS9l5Dt64kyp7v+9KeYPOCviYmVw2kM1EZRdAeo+jiCRxU5LnDJ9ORxfRwGcEmQV7xb4UpqXcn2N6Q==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/protocol-http": "3.46.0",
+        "@aws-sdk/types": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-location-constraint": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.40.0.tgz",
-      "integrity": "sha512-9XaVPYsDQVJbWJH96sNdv4HHY3j1raman+lYxMu4528Awp0OdWUeSsGRYRN+CnRPlkHnfNw4m6SKdWYHxdjshw==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.46.0.tgz",
+      "integrity": "sha512-sn9A5+LKYkXfjMwDfIb01ru8z/1t+ALERvIkILTK0YuzNRIJLPMumiuY5XhKEbte0z4+ie5yytcfW9kU2NUA6Q==",
       "requires": {
-        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/types": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-logger": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.40.0.tgz",
-      "integrity": "sha512-19kx0Xg5ymVRKoupmhdmfTBkROcv3DZj508agpyG2YAo0abOObMlIP4Jltg0VD4PhNjGzNh0jFGJnvhjdwv4/A==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.46.0.tgz",
+      "integrity": "sha512-xkB98tfZc1pSeks0a7jagYIVHxJfoxHX7wcASzBa3IjyodZpSqDW392edF9c3kSCv6G6PGRbG+F1F6j7ZTVpRQ==",
       "requires": {
-        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/types": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-retry": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.40.0.tgz",
-      "integrity": "sha512-SMUJrukugLL7YJE5X8B2ToukxMWMPwnf7jAFr84ptycCe8bdWv8x8klQ3EtVWpyqochtNlbTi6J/tTQBniUX7A==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.46.0.tgz",
+      "integrity": "sha512-YkNNs2dUcriLwy4pYG7nfa850tD8dtFUeE/IQ+YBMbWDedT31UFkCfHUdjBK1GFbIv+G1N+ZVGBCkWq1OuhKXw==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/service-error-classification": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/protocol-http": "3.46.0",
+        "@aws-sdk/service-error-classification": "3.46.0",
+        "@aws-sdk/types": "3.46.0",
         "tslib": "^2.3.0",
         "uuid": "^8.3.2"
       }
     },
     "@aws-sdk/middleware-sdk-s3": {
-      "version": "3.45.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.45.0.tgz",
-      "integrity": "sha512-V4rnR4pnCxbZOMIFLkIEejmvrW3cujB1OECsK4/fmIlxpgImwYhHbCvFRG/upe92oltehqddGtkCxglmHNMs3g==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.46.0.tgz",
+      "integrity": "sha512-5xj+9Jaur0oVZerabvD26sfoF0a158BXPrwkKLM4nm1TWJSK4JMbT0nxryzRrOylt5I86W9CRJeHVLFTpV3QKg==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/signature-v4": "3.45.0",
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/util-arn-parser": "3.37.0",
+        "@aws-sdk/protocol-http": "3.46.0",
+        "@aws-sdk/signature-v4": "3.46.0",
+        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/util-arn-parser": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-sdk-sts": {
-      "version": "3.45.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.45.0.tgz",
-      "integrity": "sha512-nvvzoKItzyZF44+0/VdygbUDgBG8wxYqDK0i+aPYLmmTu2NTBcREeMDiYO/aHZIzMNemyJqSdB3p8sdf2BYTAA==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.46.0.tgz",
+      "integrity": "sha512-JcLwMBqg0ZsHU79e4VixU7e2YI+pktRuI9HXKc4Aoic+h65TXOzB3KjAllweUNjQtc6ZZvqYdd9WJ6PFs1X93A==",
       "requires": {
-        "@aws-sdk/middleware-signing": "3.45.0",
-        "@aws-sdk/property-provider": "3.40.0",
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/signature-v4": "3.45.0",
-        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/middleware-signing": "3.46.0",
+        "@aws-sdk/property-provider": "3.46.0",
+        "@aws-sdk/protocol-http": "3.46.0",
+        "@aws-sdk/signature-v4": "3.46.0",
+        "@aws-sdk/types": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-serde": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.40.0.tgz",
-      "integrity": "sha512-uOWfZjlAoBy6xPqp0d4ka83WNNbEVCWn9WwfqBUXThyoTdTooYSpXe5y2YzN0BJa8b+tEZTyWpgamnBpFLp47g==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.46.0.tgz",
+      "integrity": "sha512-5M56VUm/stsSabauHxFrv1BSoH0VPyMB1V4vewAD3cp5YGiUpChYxjhcBbzi0QvI65HLxa6nLedwrE+g1uVJ1Q==",
       "requires": {
-        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/types": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-signing": {
-      "version": "3.45.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.45.0.tgz",
-      "integrity": "sha512-MUtKe0mRWgWimGlbDX9KWHnxcQz8g1N+gEjfkcxzw+HMIxxQIKYFgUyllhFZ3HvYIje/wLlFYuDKXRBrJjUxYQ==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.46.0.tgz",
+      "integrity": "sha512-wyv58cufJ2mWtpgfdMYs2ZPnyGadgnaZpWpdoVTpSte8PyUXjRiaR8dLkj84DWUurT6m1h7NEPIHgL6+W1Wwfg==",
       "requires": {
-        "@aws-sdk/property-provider": "3.40.0",
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/signature-v4": "3.45.0",
-        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/property-provider": "3.46.0",
+        "@aws-sdk/protocol-http": "3.46.0",
+        "@aws-sdk/signature-v4": "3.46.0",
+        "@aws-sdk/types": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-ssec": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.40.0.tgz",
-      "integrity": "sha512-ZoRpaZeAIQa1Q+NyEh74ATwOR3nFGfcP6Nu0jFzgqoVijCReMnhtlCRx23ccBu1ZLZNUsNk6MhKjY+ZTfNsjEg==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.46.0.tgz",
+      "integrity": "sha512-rIgm3HBVrHu2hutNQFZSoJOV+I+wkO9qMKkBKLEpgA9CKsRRJ1IYM6iY+/27oQvG6soydJPy2IHLlmQRZg4WxQ==",
       "requires": {
-        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/types": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-stack": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.40.0.tgz",
-      "integrity": "sha512-hby9HvESUYJxpdALX+6Dn2LPmS5jtMVurGB/+j3MWOvIcDYB4bcSXgVRvXzYnTKwbSupIdbX9zOE2ZAx2SJpUQ==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.46.0.tgz",
+      "integrity": "sha512-+3SmpYo12i9Gn7L/HEJqAv5+OieZL9zfXungFKr96rTpcvYDZWQblTP3tugBtvGV6V4tzvebMkUTWxBB6p+dhQ==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-user-agent": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.40.0.tgz",
-      "integrity": "sha512-dzC2fxWnanetFJ1oYgil8df3N36bR1yc/OCOpbdfQNiUk1FrXiCXqH5rHNO8zCvnwJAj8GHFwpFGd9a2Qube2w==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.46.0.tgz",
+      "integrity": "sha512-n9VEWlIXxbJXCr2IpocNJQUW7dhCdAcPKmxV0T5LZ/AygKsLvbWy40u2Qm9/eB1MYpqiheeb5MsY3UXxHgnOlg==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/protocol-http": "3.46.0",
+        "@aws-sdk/types": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/node-config-provider": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.40.0.tgz",
-      "integrity": "sha512-AmokjgUDECG8osoMfdRsPNweqI+L1pn4bYGk5iTLmzbBi0o4ot0U1FdX8Rf0qJZZwS4t1TXc3s8/PDVknmPxKg==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.46.0.tgz",
+      "integrity": "sha512-Hzz860d1GNZSSX74TywfUu125l8BT6JkJuKG0QDhuC+9xklNfC1hgziihldHu6xL7DzY5UKgjyzdNBQfqCqLbw==",
       "requires": {
-        "@aws-sdk/property-provider": "3.40.0",
-        "@aws-sdk/shared-ini-file-loader": "3.37.0",
-        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/property-provider": "3.46.0",
+        "@aws-sdk/shared-ini-file-loader": "3.46.0",
+        "@aws-sdk/types": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/node-http-handler": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.40.0.tgz",
-      "integrity": "sha512-qjda6IbxDhbYr8NHmrMurKkbjgLUkfTMVgagDErDK24Nm3Dn5VaO6J4n6c0Q4OLHlmFaRcUfZSTrOo5DAubqCw==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.46.0.tgz",
+      "integrity": "sha512-SqeKskt47u/ZIeN5b6lmjOAx0yLiY/WDQ6N9Z6LRJCYiSZ7oHflA1jPWkX20qWOKioa2iHBVTNNX2lu8yFkWbg==",
       "requires": {
-        "@aws-sdk/abort-controller": "3.40.0",
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/querystring-builder": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/abort-controller": "3.46.0",
+        "@aws-sdk/protocol-http": "3.46.0",
+        "@aws-sdk/querystring-builder": "3.46.0",
+        "@aws-sdk/types": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/property-provider": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.40.0.tgz",
-      "integrity": "sha512-Mx4lkShjsYRwW9ujHA1pcnuubrWQ4kF5/DXWNfUiXuSIO/0Lojp1qTLheyBm4vzkJIlx5umyP6NvRAUkEHSN4Q==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.46.0.tgz",
+      "integrity": "sha512-e3Jcds7G1Hg5VDvwLox0HlQq4G2fvmkO1BRPvM8WfRGvxRNK40dqoelm2NMtbNK0KgFPIpKsGeX1UhZDt9Od9w==",
       "requires": {
-        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/types": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/protocol-http": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.40.0.tgz",
-      "integrity": "sha512-f4ea7/HZkjpvGBrnRIuzc/bhrExWrgDv7eulj4htPukZGHdTqSJD3Jk8lEXWvFuX2vUKQDGhEhCDsqup7YWJQQ==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.46.0.tgz",
+      "integrity": "sha512-hKqHYEp/JDfOl5kZKp0CRgvbsg+c52Ss4KwuRoU9vA56VZ5TpfgHznajdme97xedsE40hnZeitv2BKEMbkYCqg==",
       "requires": {
-        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/types": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/querystring-builder": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.40.0.tgz",
-      "integrity": "sha512-gO24oipnNaxJRBXB7lhLfa96vIMOd8gtMBqJTjelTjS2e1ZP1YY12CNKKTWwafSk8Ge021erZAG/YTOaXGpv+g==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.46.0.tgz",
+      "integrity": "sha512-YYGRK291ro+KR3TX0jjyGRdMGHn6D2CBD89oXj8tAV3djeMIpFSGDrEL+NKeJvp7aBNlEnQ9kSfzyQuzQVvJWA==",
       "requires": {
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/util-uri-escape": "3.37.0",
+        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/util-uri-escape": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/querystring-parser": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.40.0.tgz",
-      "integrity": "sha512-XZIyaKQIiZAM6zelCBcsLHhVDOLafi7XIOd3jy6SymGN8ajj3HqUJ/vdQ5G6ISTk18OrqgqcCOI9oNzv+nrBcA==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.46.0.tgz",
+      "integrity": "sha512-xxTnIXLbx4Jq16Utza7wh4HpPfVyCL0c+6NU2t+kXZ2sgOWhx2XAhShcZVbEkA/61UAMEIhyNBVE+z9OFz6X5g==",
       "requires": {
-        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/types": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/s3-request-presigner": {
-      "version": "3.45.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.45.0.tgz",
-      "integrity": "sha512-kwL9rzvX5cMY0VQq+/mWcSl9l2Cut60UpR3J91KvCn7WYCr4QtNlni9w6MO7qdJWZldvlYgoMdCuxi+0lrzvbA==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.46.0.tgz",
+      "integrity": "sha512-pnnjGf4agTr21i4jvAgxUWqy3LBwoOIkLLXCD/tCYgTzcmbf1q/gVu+09+GVGNlLyo0ONatNTfpdS2FJ7XNf9Q==",
       "requires": {
-        "@aws-sdk/middleware-sdk-s3": "3.45.0",
-        "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/signature-v4": "3.45.0",
-        "@aws-sdk/smithy-client": "3.41.0",
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/util-create-request": "3.41.0",
-        "@aws-sdk/util-format-url": "3.40.0",
+        "@aws-sdk/middleware-sdk-s3": "3.46.0",
+        "@aws-sdk/protocol-http": "3.46.0",
+        "@aws-sdk/signature-v4": "3.46.0",
+        "@aws-sdk/smithy-client": "3.46.0",
+        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/util-create-request": "3.46.0",
+        "@aws-sdk/util-format-url": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/service-error-classification": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.40.0.tgz",
-      "integrity": "sha512-c8btKmkvjXczWudXubGdbO3JgmjySBUVC/gCrZDNfwNGsG8RYJJQYYcnmt1gWjelUZsgMDl/2PIzxTlxVF91rA=="
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.46.0.tgz",
+      "integrity": "sha512-hFDh/qtvKX9xUPxjGiDvumKsoO/3+eL4hi6X3qWN8lHg49wixjwcwlCEPn9jhdFJ9TRXc20CgPxWv4+V96Yf/A=="
     },
     "@aws-sdk/shared-ini-file-loader": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.37.0.tgz",
-      "integrity": "sha512-+vRBSlfa48R9KL7DpQt3dsu5/+5atjRgoCISblWo3SLpjrx41pKcjKneo7a1u0aP1Xc2oG2TfIyqTWZuOXsmEQ==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.46.0.tgz",
+      "integrity": "sha512-Rp7Z1X23kvyRCziOxXu2PYCCPT5CQ5t8O4WoKrEkMT9Vqm2gluXOcCnL4iOpRkSRGEZT7lfe5OCM8ApNRTIHpQ==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/signature-v4": {
-      "version": "3.45.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.45.0.tgz",
-      "integrity": "sha512-73dwNe4R4Ytgn82gV8B99tE6UqrWjHE1JIAXpEZeXsBPJtg+8wpgd9sujs6JH9JW2cvnSnIsCXs1gQGD9+bZ0A==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.46.0.tgz",
+      "integrity": "sha512-qtI1t0CrEhVCxaezmmBpMe1WmQxdxho8oPiMEKWIUkkXQFg78Eg3jnXlLhjL4+MGHMqBB3mV7nGO6k8qu8H9rA==",
       "requires": {
-        "@aws-sdk/is-array-buffer": "3.37.0",
-        "@aws-sdk/types": "3.40.0",
-        "@aws-sdk/util-hex-encoding": "3.37.0",
-        "@aws-sdk/util-uri-escape": "3.37.0",
+        "@aws-sdk/is-array-buffer": "3.46.0",
+        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/util-hex-encoding": "3.46.0",
+        "@aws-sdk/util-uri-escape": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/smithy-client": {
-      "version": "3.41.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.41.0.tgz",
-      "integrity": "sha512-ldhS0Pf3v6yHCd//kk5DvKcdyeUkKEwxNDRanAp+ekTW68J3XcYgKaPC9sNDhVTDH1zrywTvtEz5zWHEvXjQow==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.46.0.tgz",
+      "integrity": "sha512-Dzx4CR+rOkr5hXbLhnOfnrPWmSs4O9BTjFWD+4oh+RTXq0It8g+fWZxPcdvRCDU4GjS9Gtbkw0f0pN3FMCEszQ==",
       "requires": {
-        "@aws-sdk/middleware-stack": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/middleware-stack": "3.46.0",
+        "@aws-sdk/types": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/types": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.40.0.tgz",
-      "integrity": "sha512-KpILcfvRaL88TLvo3SY4OuCCg90SvcNLPyjDwUuBqiOyWODjrKShHtAPJzej4CLp92lofh+ul0UnBfV9Jb/5PA=="
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.46.0.tgz",
+      "integrity": "sha512-yhrkVVyv4RUt3KqDDyEayjBM5dRBtuS486THeqtSghUYNV7M/cW18TA3gdMC0pRGgUqfKrOysdBZjCyPrYNvuA=="
     },
     "@aws-sdk/url-parser": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.40.0.tgz",
-      "integrity": "sha512-HwNV+HX7bHgLk5FzTOgdXANsC0SeVz5PMC4Nh+TLz2IoeQnrw4H8dsA4YNonncjern5oC5veKRjQeOoCL5SlSQ==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.46.0.tgz",
+      "integrity": "sha512-foMB0AC3QDy+KfvRxsMXvJQZXr9CMzdupcNIXwKRZog82tEEc09dVeUjuJrO4H+A2eK84SyawRfy+ow+LRqvqw==",
       "requires": {
-        "@aws-sdk/querystring-parser": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/querystring-parser": "3.46.0",
+        "@aws-sdk/types": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-arn-parser": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.37.0.tgz",
-      "integrity": "sha512-njIYn8gzm7Ms17A2oEu0vN/0GJpgq7cNFFtzBrM1cPtrc1jhMRJx5hzS7uX5h6ll8BM92bA3y00evRZFHxQPVQ==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.46.0.tgz",
+      "integrity": "sha512-MIeqH53/Z5x+uQ/EHs6zqkdBqdpGA8tA6l/mL1j8hRK6bSQEUTAVlPNgjp03qse1Fk94GJbJbjZ4C0R7Z4YM+g==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-base64-browser": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.37.0.tgz",
-      "integrity": "sha512-o4s/rHVm5k8eC/T7grJQINyYA/mKfDmEWKMA9wk5iBroXlI2rUm7x649TBk5hzoddufk/mffEeNz/1wM7yTmlg==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.46.0.tgz",
+      "integrity": "sha512-oDlExDHYVOXsHFwFCA+CxZlGiHWeO53l0xoohpTIwGV6u48jED/4GrNM6iWVT6Vwd4skqtRMM41IHXjtiCtp/g==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-base64-node": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.37.0.tgz",
-      "integrity": "sha512-1UPxly1GPrGZtlIWvbNCDIAund4Oyp8cFi9neA43TeNACvrmEQu/nG01pDbOoo0ENoVSVJrNAVBeqKEpqjH2GA==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.46.0.tgz",
+      "integrity": "sha512-/ruNBm21Ptk+IGhwTphs8j5oDCjNIrUSipDoRtUuMGQR9TnNzup0e+sJDqP0BrKKM+tcvqEUhz+MScxbwJrwmg==",
       "requires": {
-        "@aws-sdk/util-buffer-from": "3.37.0",
+        "@aws-sdk/util-buffer-from": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-body-length-browser": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.37.0.tgz",
-      "integrity": "sha512-tClmH1uYelqWT43xxmnOsVFbCQJiIwizp6y4E109G2LIof07inxrO0L8nbwBpjhugVplx6NZr9IaqTFqbdM1gA==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.46.0.tgz",
+      "integrity": "sha512-OJgMlBv4gEdmHCdZO9htysz9GMw0mS7qB3I5CbZ2aBOM0NvmaU7nqI6zYCoEmGh0keq0CnMBlNZhBBAwtiKYqg==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-body-length-node": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.37.0.tgz",
-      "integrity": "sha512-aY3mXdbEajruRi9CHgq/heM89R+Gectj/Xrs1naewmamaN8NJrvjDm3s+cw//lqqSOW903LYHXDgm7wvCzUnFA==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.46.0.tgz",
+      "integrity": "sha512-jyD+2c7iaD4Aih93Fm4I183SbdhSy4FNmSlK49PctMVVF+QSpzQxAJvv/nTwq37Kb8orVvs+sgy2FF3lxfOUJg==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-buffer-from": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.37.0.tgz",
-      "integrity": "sha512-aa3SBwjLwImuJoE4+hxDIWQ9REz3UFb3p7KFPe9qopdXb/yB12RTcbrXVb4whUux4i4mO6KRij0ZNjFZrjrKPg==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.46.0.tgz",
+      "integrity": "sha512-e3avbwAUULpPCk4ke9ctrhAwxcXvMv8FYymNJDEN7+9lqZ4XqAjPt+R+IEEFMEbWmIPeZ8TpLw3yuru1Z74iuA==",
       "requires": {
-        "@aws-sdk/is-array-buffer": "3.37.0",
+        "@aws-sdk/is-array-buffer": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-config-provider": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.40.0.tgz",
-      "integrity": "sha512-NjZGrA4mqhpr6gkVCAUweurP0Z9d3vFyXJCtulC0BFbpKAnKCf/crSK56NwUaNhAEMCkSuBvjRFzkbfT+HO8bA==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.46.0.tgz",
+      "integrity": "sha512-KzzusGkvmb1uy3EItl+9YRxOOtjmU6iaAi9pBzHR2fiv13EMVNZrycVFPeGwz6LrsAEumKmTAZjR6c8BRbxtjw==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-create-request": {
-      "version": "3.41.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-create-request/-/util-create-request-3.41.0.tgz",
-      "integrity": "sha512-mKTMCDTaQ9HH+ppg1QMcBiSlbvRmw8AOllXTkYS1pdO7gi/Sl21krXfIja2MakuK6cB6D+B8MFP8rfq14Vhhlg==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-create-request/-/util-create-request-3.46.0.tgz",
+      "integrity": "sha512-Fu42fGq9Jgu2s3PP008QDOomuWB1+MjOTei3YEKpnvhOV9MxgqA68WdCbbpKBR3y3E/3auwDbtSt4ddB0MFaMg==",
       "requires": {
-        "@aws-sdk/middleware-stack": "3.40.0",
-        "@aws-sdk/smithy-client": "3.41.0",
-        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/middleware-stack": "3.46.0",
+        "@aws-sdk/smithy-client": "3.46.0",
+        "@aws-sdk/types": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-credentials": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.37.0.tgz",
-      "integrity": "sha512-zcLhSZDKgBLhUjSU5HoQpuQiP3v8oE86NmV/tiZVPEaO6YVULEAB2Cfj1hpM/b/JXWzjSHfT06KXT7QUODKS+A==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.46.0.tgz",
+      "integrity": "sha512-d5bDyCDVYi6ThBY8AntAKooExayFuLUnCXsDkmmWpHlp26JZv9s1/DsXR219ELgu8jIAWiID54HjfEYf8qa6Vw==",
       "requires": {
-        "@aws-sdk/shared-ini-file-loader": "3.37.0",
+        "@aws-sdk/shared-ini-file-loader": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-format-url": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.40.0.tgz",
-      "integrity": "sha512-eOKeYwAvsCQjTSCAW1LVhnjmTyyGK6lZjGTa9wXxxjVE6Fhc66+cCykS8u/u8Vj7BCS+ixiLetXtH1/qd+Bl+g==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.46.0.tgz",
+      "integrity": "sha512-Wae7sLWA29uy4TLLN8PjqR5DPmosqbFR9oARGCxegzFcha9adu88CD2Y9mU7zCF6fFymu/NHpNTEQkX+VdFX/w==",
       "requires": {
-        "@aws-sdk/querystring-builder": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/querystring-builder": "3.46.0",
+        "@aws-sdk/types": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-hex-encoding": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.37.0.tgz",
-      "integrity": "sha512-tn5UpfaeM+rZWqynoNqB8lwtcAXil5YYO3HLGH9himpWAdft/2Z7LK6bsYDpctaAI1WHgMDcL0bw3Id04ZUbhA==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.46.0.tgz",
+      "integrity": "sha512-A831jS32tbdjki4ihS0BIZ3HAi1gv2PtLmAjAW+PHVvBd0S4OpbQApKxKPu0w+NKsp9XQYfkEkeFKCcMqN1zhg==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-locate-window": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.37.0.tgz",
-      "integrity": "sha512-NvDCfOhLLVHp27oGUUs8EVirhz91aX5gdxGS7J/sh5PF0cNN8rwaR1vSLR7BxPmJHMO7NH7i9EwiELfLfYcq6g==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.46.0.tgz",
+      "integrity": "sha512-g6V/7mozjlP2HhwHHgGgoOvcNRJasIQjh7ClkCMrMilfthD4WNtkWfcAZQD+BaPKkSgj8MnIOFvFzqULGeNQXA==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-uri-escape": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.37.0.tgz",
-      "integrity": "sha512-8pKf4YJTELP5lm/CEgYw2atyJBB1RWWqFa0sZx6YJmTlOtLF5G6raUdAi4iDa2hldGt2B6IAdIIyuusT8zeU8Q==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.46.0.tgz",
+      "integrity": "sha512-drAHEt3YnI6H6NpiTFLFT8e75bOhaO94ZP+kqz/0hluQiKX47Pow3Ar3Diaf/CUMLctH0IX3AaN3T2ve5v19lQ==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-user-agent-browser": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.40.0.tgz",
-      "integrity": "sha512-C69sTI26bV2EprTv3DTXu9XP7kD9Wu4YVPBzqztOYArd2GDYw3w+jS8SEg3XRbjAKY/mOPZ2Thw4StjpZlWZiA==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.46.0.tgz",
+      "integrity": "sha512-wwUh4H6+ur9akctoSgaz41J8JuRrOqey4aY68DmDQ0did3UjhRlbPD3xu0umXoPSgmtqQyl34oMPqCOfA70Z0Q==",
       "requires": {
-        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/types": "3.46.0",
         "bowser": "^2.11.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-user-agent-node": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.40.0.tgz",
-      "integrity": "sha512-cjIzd0hRZFTTh7iLJD6Bciu++Em1iaM1clyG02xRl0JD5DEtDSR1zO02uu+AeM7GSLGOxIvwOkK2j8ySPAOmBA==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.46.0.tgz",
+      "integrity": "sha512-JCY8mKWPic0aXtz7amKXWyjbX8fhdOkRcgsCCnevOHc/7KOxwa97VnDT555GNQ76LO+cEDgYueHklUayV3u+IA==",
       "requires": {
-        "@aws-sdk/node-config-provider": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/node-config-provider": "3.46.0",
+        "@aws-sdk/types": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-utf8-browser": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.37.0.tgz",
-      "integrity": "sha512-tuiOxzfqet1kKGYzlgpMGfhr64AHJnYsFx2jZiH/O6Yq8XQg43ryjQlbJlim/K/XHGNzY0R+nabeJg34q3Ua1g==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.46.0.tgz",
+      "integrity": "sha512-zafI5Y7hRVC0vhJ77FPUyBckmpF2v2ZEKFC79AdwdFX11l7XNmq0hY/4CWVYeZ2L0Fyk0UV6eeKyk/TNdce0mg==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-utf8-node": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.37.0.tgz",
-      "integrity": "sha512-fUAgd7UTCULL36j9/vnXHxVhxvswnq23mYgTCIT8NQ7wHN30q2a89ym1e9DwGeQkJEBOkOcKLn6nsMsN7YQMDQ==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.46.0.tgz",
+      "integrity": "sha512-Uk9hQrWQowU4ymtSxrxiIp7GnBoZfkKGSeWDy2h/1Biaexq9FQclbgwa0ZhA5lKLDj/nUxnXoT/ZcY90mTdzzQ==",
       "requires": {
-        "@aws-sdk/util-buffer-from": "3.37.0",
+        "@aws-sdk/util-buffer-from": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-waiter": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.40.0.tgz",
-      "integrity": "sha512-jdxwNEZdID49ZvyAnxaeNm5w2moIfMLOwj/q6TxKlxYoXMs16FQWkhyfGue0vEASzchS49ewbyt+KBqpT31Ebg==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.46.0.tgz",
+      "integrity": "sha512-rn1bf9whuHfarNTFSRnFIupRlfN+L28hRZL8PClgyxa0WqpzG0goN6M+opuYnbKrTazyqktxpUTg/fHHoQiveA==",
       "requires": {
-        "@aws-sdk/abort-controller": "3.40.0",
-        "@aws-sdk/types": "3.40.0",
+        "@aws-sdk/abort-controller": "3.46.0",
+        "@aws-sdk/types": "3.46.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/xml-builder": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.37.0.tgz",
-      "integrity": "sha512-Vf0f4ZQ+IBo/l9wUaTOXLqqQO9b/Ll5yPbg+EhHx8zlHbTHIm89ettkVCGyT/taGagC1X+ZeTK9maX6ymEOBow==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.46.0.tgz",
+      "integrity": "sha512-CeqtrNiyA4c9GeX5HJNTrMohHKm6haEeX8Nzkc//whRgXb9UEj++JMd5SxCTmO3TEIO1QmmoScSMiiywOeoDiQ==",
       "requires": {
         "tslib": "^2.3.0"
       }
@@ -1230,9 +1230,9 @@
       "dev": true
     },
     "@nimbella/nimbella-deployer": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-3.1.6.tgz",
-      "integrity": "sha512-wrVhugoZrG6phP2q+kIeA8AIgipjYBYXM7YxeMu3AFKKDsgmB+wRpAhIeBoNtzX2QXEkqFES7XsRGL+5WdxnZw==",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-3.1.8.tgz",
+      "integrity": "sha512-imK2C+FUB8ZnvEdn1IBh8+mL9elE/iX1aZAH1eJEc9KUEg0NW/SucvlGJxcFu0oJ4yVm5gC0/Ovvkt1ekVIK+w==",
       "requires": {
         "@nimbella/sdk": "^1.3.5",
         "@nimbella/storage": "^0.0.7",
@@ -1249,7 +1249,7 @@
         "memory-streams": "^0.1.3",
         "mime-db": "^1.45.0",
         "mime-types": "^2.1.22",
-        "openwhisk": "3.21.5",
+        "openwhisk": "3.21.6",
         "randomstring": "^1.1.5",
         "rimraf": "^3.0.1",
         "simple-git": "^1.113.0",
@@ -1266,15 +1266,6 @@
           "version": "5.0.6",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.0.6.tgz",
           "integrity": "sha512-/+hp3kUf/Csa32ktIaj0OlRqQxrgs30n62M90UBpNd9k+ENEch5S+hmbW3DtcJGz3sYFTh4F3A6fQ0q7KWsp4w=="
-        },
-        "openwhisk": {
-          "version": "3.21.5",
-          "resolved": "https://registry.npmjs.org/openwhisk/-/openwhisk-3.21.5.tgz",
-          "integrity": "sha512-u23z6RDtzv2DqAtL4RxfQBVlcTy8M2fKl1SGfRbuvHxs7Xbj0mHpObddmm2oAiGvBXXGtnfSPl9ER2LXJEO66Q==",
-          "requires": {
-            "async-retry": "^1.3.3",
-            "needle": "^2.4.0"
-          }
         }
       }
     },
@@ -3843,9 +3834,9 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "follow-redirects": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.6.tgz",
-      "integrity": "sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A=="
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
     },
     "fs-constants": {
       "version": "1.0.0",
@@ -4077,11 +4068,11 @@
       }
     },
     "google-p12-pem": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.1.2.tgz",
-      "integrity": "sha512-tjf3IQIt7tWCDsa0ofDQ1qqSCNzahXDxdAGJDbruWqu3eCg5CKLYKN+hi0s6lfvzYZ1GDVr+oDF9OOWlDSdf0A==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.1.3.tgz",
+      "integrity": "sha512-MC0jISvzymxePDVembypNefkAQp+DRP7dBE+zNUPaIjEspIlYg0++OrsNr248V9tPbz6iqtZ7rX1hxWA5B8qBQ==",
       "requires": {
-        "node-forge": "^0.10.0"
+        "node-forge": "^1.0.0"
       }
     },
     "graceful-fs": {
@@ -5025,9 +5016,9 @@
       }
     },
     "node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.2.1.tgz",
+      "integrity": "sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w=="
     },
     "node-releases": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@adobe/aio-cli-plugin-runtime": "github:nimbella/aio-cli-plugin-runtime#v2021-11-19-1",
     "@adobe/aio-lib-core-config": "^2.0.0",
     "@adobe/aio-lib-runtime": "^2.0.0",
-    "@nimbella/nimbella-deployer": "^3.1.6",
+    "@nimbella/nimbella-deployer": "^3.1.8",
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-autocomplete": "^0.3.0",

--- a/src/commands/project/get-metadata.ts
+++ b/src/commands/project/get-metadata.ts
@@ -14,7 +14,7 @@
 import { flags } from '@oclif/command'
 import {
   readProject, Flags, isGithubRef, getGithubAuth, authPersister, inBrowser, makeIncluder,
-  getRuntimeForAction, emptyStructure
+  getRuntimeForAction
 } from '@nimbella/nimbella-deployer'
 
 import { NimBaseCommand, NimLogger } from '../../NimBaseCommand'

--- a/src/commands/project/get-metadata.ts
+++ b/src/commands/project/get-metadata.ts
@@ -57,16 +57,14 @@ export class ProjectMetadata extends NimBaseCommand {
     const includer = makeIncluder(flags.include, flags.exclude)
 
     // Read the project
-    let result = await readProject(args.project, env, undefined, includer, false, undefined, {})
-    const unresolvedVariables = result.unresolvedVariables
-    if (unresolvedVariables) {
-      result = Object.assign(emptyStructure(), { unresolvedVariables })
-    } else if (result.error) {
+    const result = await readProject(args.project, env, undefined, includer, false, undefined, {})
+    if (result.error && !result.unresolvedVariables) {
       logger.handleError('  ', result.error)
     }
 
     // Fill in any missing runtimes
-    if (result.packages) {
+    if (result.packages && !result.unresolvedVariables) {
+      // Too dangerous to attempt this if the parse wasn't perfect
       for (const pkg of result.packages) {
         if (pkg.actions) {
           for (const action of pkg.actions) {


### PR DESCRIPTION
It is now possible to get back a largely valid structure with variables missing.  So, the error handling in `project get-metadata` should take that into account and display all the information it has.

For this change to be effective, it requires a change in the deployer.  So, the merge of this PR should wait on the release of a new deployer.   The dependency update can then be incorporated in this PR prior to merge.