### PR TITLE
Establish global --json flag, unify some uses

### DIFF
--- a/src/commands/auth/current.ts
+++ b/src/commands/auth/current.ts
@@ -74,7 +74,8 @@ export default class AuthInspect extends NimBaseCommand {
     if (Object.keys(ans).length === 1) {
       logger.log(String(Object.values(ans)[0]))
     } else {
-      logger.log(JSON.stringify(ans, null, 2))
+      // The 'json' flag is not consulted because JSON output is assumed
+      logger.logJSON(ans)
     }
   }
 }

--- a/src/commands/auth/export.ts
+++ b/src/commands/auth/export.ts
@@ -24,7 +24,6 @@ export default class AuthExport extends NimBaseCommand {
   static flags = {
     apihost: flags.string({ description: 'API host serving the namespace' }),
     'non-expiring': flags.boolean({ description: 'Generate non-expiring token (for functional ids and integrations)' }),
-    json: flags.boolean({ description: 'Get response as a JSON object with a "token:" member' }),
     ...NimBaseCommand.flags
   }
 

--- a/src/commands/key-value/list.ts
+++ b/src/commands/key-value/list.ts
@@ -23,7 +23,6 @@ export default class KeysList extends NimBaseCommand {
 
     static flags = {
       apihost: flags.string({ description: 'API host of the namespace to list keys from' }),
-      json: flags.boolean({ char: 'j', description: 'Displays output in JSON form' }),
       namespace: flags.string({ description: 'The namespace to list keys from (current namespace if omitted)' }),
       ...NimBaseCommand.flags
     }

--- a/src/commands/object/list.ts
+++ b/src/commands/object/list.ts
@@ -23,7 +23,6 @@ export default class ObjectsList extends NimBaseCommand {
     static flags = {
       apihost: flags.string({ description: 'API host of the namespace to list objects from' }),
       long: flags.boolean({ char: 'l', description: 'Displays additional object info such as last update, owner and md5hash' }),
-      json: flags.boolean({ char: 'j', description: 'Displays output in JSON form' }),
       namespace: flags.string({ description: 'The namespace to list objects from (current namespace if omitted)' }),
       ...NimBaseCommand.flags
     }

--- a/src/commands/project/get-metadata.ts
+++ b/src/commands/project/get-metadata.ts
@@ -28,13 +28,14 @@ export class ProjectMetadata extends NimBaseCommand {
     ...NimBaseCommand.flags
   }
 
-  static args = [{ name: 'project', description: 'The project whose metadata is requested' }]
+  static args = [{ name: 'project', description: 'The project whose metadata is requested', required: true }]
 
-  async runCommand(_rawArgv: string[], argv: string[], args: any, flags: any, logger: NimLogger): Promise<void> {
-    const isGithub = argv.some(project => isGithubRef(project))
+  async runCommand(_rawArgv: string[], _argv: string[], args: any, flags: any, logger: NimLogger): Promise<void> {
+    const project = args.project
+    const isGithub = isGithubRef(project)
     const { env, include, exclude } = flags
     if (inBrowser && !isGithub) {
-      logger.handleError('only GitHub projects are deployable from the cloud')
+      logger.handleError('only GitHub projects are accessible from the cloud')
     }
     if (isGithub && !flags['anon-github'] && !getGithubAuth(authPersister)) {
       logger.handleError('you don\'t have GitHub authorization.  Use \'nim auth github --initial\' to activate it.')

--- a/src/commands/web/list.ts
+++ b/src/commands/web/list.ts
@@ -23,7 +23,6 @@ export default class WebList extends NimBaseCommand {
     static flags = {
       apihost: flags.string({ description: 'API host of the namespace to list web content from' }),
       long: flags.boolean({ char: 'l', description: 'Displays additional file info such as last update, owner and md5hash' }),
-      json: flags.boolean({ char: 'j', description: 'Displays output in JSON form' }),
       namespace: flags.string({ description: 'The namespace to list web content from (current namespace if omitted)' }),
       ...NimBaseCommand.flags
     }


### PR DESCRIPTION
The CLI is often used in scripts or in a dependent fashion (through the library interface) in which case a more structured form of output is desirable.

Some commands have a `--json` flag but one has to know which.   With this change, there is a global `--json` flag so that flag will be accepted on every command.

Not all commands will respond to this flag by actually issuing JSON, so think of it as advisory.    But, part of this PR is to make sure that all commands that do honor a `--json` flag are using the global one and are using the recommended method of `NimLogger (`logJSON`).   There will be follow-on work to make more and more commands conform to the implied mandate of the flag.