### PR TITLE
Support --json flag in 'nim auth' and 'nim project' topics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -201,839 +201,869 @@
       }
     },
     "@aws-sdk/abort-controller": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.46.0.tgz",
-      "integrity": "sha512-XrCocRwajh3jkI/Y2PCZjYUZcJfmCa4DYM5nnW2+w4o7ez7vXEQ1j5FCI+/ogJIqfccnmEIlLZGlfzmc6vVbJw==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.47.0.tgz",
+      "integrity": "sha512-6sxt11dVaJT8CzfVsGCV3h2R0LO12fvXsvCZsMsPGtivb4ZgoFK+PO3hs+9xuA3zjMUC7mb6LE2RM8EXKBDjDw==",
       "requires": {
-        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/types": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/chunked-blob-reader": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.46.0.tgz",
-      "integrity": "sha512-wd2vDT0mjEuOO0IqeWs2CGRWe164I7oeplnkKEC1vG9Bpjww+1u3LoJ1de6plFSLwAoBpqtmIt4koQl5NCyUyQ==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.47.0.tgz",
+      "integrity": "sha512-R8kXhgz7Ys6Esi2jCWQd+0ZCs9aXGFPWPeMVtefDTZuUSr/rX6vnq1+qouyv44UXe+MOmYT5qTkho+sFh2dPvA==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/chunked-blob-reader-native": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.46.0.tgz",
-      "integrity": "sha512-6Oa10XjddRlAooRN5vGI2fBAk5fmLjuR9HHHlcuygnfefXkdmTKaRVSIX0Tdh/rwGz+npOjESaqtKHgMv81gJw==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.47.0.tgz",
+      "integrity": "sha512-Th5amimvBEGSBgOOhqQb2w8ii38QFHocfQaK5pC1sBkn8H57UZ965yrCHoFlvEWAUgR0j0et+WeWNx+0wkAQRQ==",
       "requires": {
-        "@aws-sdk/util-base64-browser": "3.46.0",
+        "@aws-sdk/util-base64-browser": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/client-s3": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.46.0.tgz",
-      "integrity": "sha512-4/p1KQUVRkdhFSh17trEs026SE3fkNkes5zvAD2R385yRJ0i2ImKV2pjzOXDKLcol0X45Ix44KXI3uUE5W8V9A==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.47.0.tgz",
+      "integrity": "sha512-qKd6nx/fvA+UY3G4+HbQUw1uB+yEwaUO/QSLhFO6O0Ci2ZjErDAdrZJKMc0S3C93hLfotN/ABFUFPiTbokLziw==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.46.0",
-        "@aws-sdk/config-resolver": "3.46.0",
-        "@aws-sdk/credential-provider-node": "3.46.0",
-        "@aws-sdk/eventstream-serde-browser": "3.46.0",
-        "@aws-sdk/eventstream-serde-config-resolver": "3.46.0",
-        "@aws-sdk/eventstream-serde-node": "3.46.0",
-        "@aws-sdk/fetch-http-handler": "3.46.0",
-        "@aws-sdk/hash-blob-browser": "3.46.0",
-        "@aws-sdk/hash-node": "3.46.0",
-        "@aws-sdk/hash-stream-node": "3.46.0",
-        "@aws-sdk/invalid-dependency": "3.46.0",
-        "@aws-sdk/md5-js": "3.46.0",
-        "@aws-sdk/middleware-apply-body-checksum": "3.46.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.46.0",
-        "@aws-sdk/middleware-content-length": "3.46.0",
-        "@aws-sdk/middleware-expect-continue": "3.46.0",
-        "@aws-sdk/middleware-host-header": "3.46.0",
-        "@aws-sdk/middleware-location-constraint": "3.46.0",
-        "@aws-sdk/middleware-logger": "3.46.0",
-        "@aws-sdk/middleware-retry": "3.46.0",
-        "@aws-sdk/middleware-sdk-s3": "3.46.0",
-        "@aws-sdk/middleware-serde": "3.46.0",
-        "@aws-sdk/middleware-signing": "3.46.0",
-        "@aws-sdk/middleware-ssec": "3.46.0",
-        "@aws-sdk/middleware-stack": "3.46.0",
-        "@aws-sdk/middleware-user-agent": "3.46.0",
-        "@aws-sdk/node-config-provider": "3.46.0",
-        "@aws-sdk/node-http-handler": "3.46.0",
-        "@aws-sdk/protocol-http": "3.46.0",
-        "@aws-sdk/smithy-client": "3.46.0",
-        "@aws-sdk/types": "3.46.0",
-        "@aws-sdk/url-parser": "3.46.0",
-        "@aws-sdk/util-base64-browser": "3.46.0",
-        "@aws-sdk/util-base64-node": "3.46.0",
-        "@aws-sdk/util-body-length-browser": "3.46.0",
-        "@aws-sdk/util-body-length-node": "3.46.0",
-        "@aws-sdk/util-user-agent-browser": "3.46.0",
-        "@aws-sdk/util-user-agent-node": "3.46.0",
-        "@aws-sdk/util-utf8-browser": "3.46.0",
-        "@aws-sdk/util-utf8-node": "3.46.0",
-        "@aws-sdk/util-waiter": "3.46.0",
-        "@aws-sdk/xml-builder": "3.46.0",
+        "@aws-sdk/client-sts": "3.47.0",
+        "@aws-sdk/config-resolver": "3.47.0",
+        "@aws-sdk/credential-provider-node": "3.47.0",
+        "@aws-sdk/eventstream-serde-browser": "3.47.0",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.47.0",
+        "@aws-sdk/eventstream-serde-node": "3.47.0",
+        "@aws-sdk/fetch-http-handler": "3.47.0",
+        "@aws-sdk/hash-blob-browser": "3.47.0",
+        "@aws-sdk/hash-node": "3.47.0",
+        "@aws-sdk/hash-stream-node": "3.47.0",
+        "@aws-sdk/invalid-dependency": "3.47.0",
+        "@aws-sdk/md5-js": "3.47.0",
+        "@aws-sdk/middleware-apply-body-checksum": "3.47.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.47.0",
+        "@aws-sdk/middleware-content-length": "3.47.0",
+        "@aws-sdk/middleware-expect-continue": "3.47.0",
+        "@aws-sdk/middleware-host-header": "3.47.0",
+        "@aws-sdk/middleware-location-constraint": "3.47.0",
+        "@aws-sdk/middleware-logger": "3.47.0",
+        "@aws-sdk/middleware-retry": "3.47.0",
+        "@aws-sdk/middleware-sdk-s3": "3.47.0",
+        "@aws-sdk/middleware-serde": "3.47.0",
+        "@aws-sdk/middleware-signing": "3.47.0",
+        "@aws-sdk/middleware-ssec": "3.47.0",
+        "@aws-sdk/middleware-stack": "3.47.0",
+        "@aws-sdk/middleware-user-agent": "3.47.0",
+        "@aws-sdk/node-config-provider": "3.47.0",
+        "@aws-sdk/node-http-handler": "3.47.0",
+        "@aws-sdk/protocol-http": "3.47.0",
+        "@aws-sdk/smithy-client": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/url-parser": "3.47.0",
+        "@aws-sdk/util-base64-browser": "3.47.0",
+        "@aws-sdk/util-base64-node": "3.47.0",
+        "@aws-sdk/util-body-length-browser": "3.47.0",
+        "@aws-sdk/util-body-length-node": "3.47.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.47.0",
+        "@aws-sdk/util-defaults-mode-node": "3.47.0",
+        "@aws-sdk/util-user-agent-browser": "3.47.0",
+        "@aws-sdk/util-user-agent-node": "3.47.0",
+        "@aws-sdk/util-utf8-browser": "3.47.0",
+        "@aws-sdk/util-utf8-node": "3.47.0",
+        "@aws-sdk/util-waiter": "3.47.0",
+        "@aws-sdk/xml-builder": "3.47.0",
         "entities": "2.2.0",
         "fast-xml-parser": "3.19.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.46.0.tgz",
-      "integrity": "sha512-n+dHT9azUW4pFA7a98gV/qFYdNwoMQ/4Y4tvPE28s9CKx8O0OIDlOwLPrhSBETCuRJNfnug1vNnFIzvOapfCkg==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.47.0.tgz",
+      "integrity": "sha512-akkyVuElsSiCCUSGIIZjIhSaPg6hjebffjtcfn1yNHTrZchKw02htUpl4BJUpZE2patFABIDhaW4UK3xPtklAQ==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.46.0",
-        "@aws-sdk/fetch-http-handler": "3.46.0",
-        "@aws-sdk/hash-node": "3.46.0",
-        "@aws-sdk/invalid-dependency": "3.46.0",
-        "@aws-sdk/middleware-content-length": "3.46.0",
-        "@aws-sdk/middleware-host-header": "3.46.0",
-        "@aws-sdk/middleware-logger": "3.46.0",
-        "@aws-sdk/middleware-retry": "3.46.0",
-        "@aws-sdk/middleware-serde": "3.46.0",
-        "@aws-sdk/middleware-stack": "3.46.0",
-        "@aws-sdk/middleware-user-agent": "3.46.0",
-        "@aws-sdk/node-config-provider": "3.46.0",
-        "@aws-sdk/node-http-handler": "3.46.0",
-        "@aws-sdk/protocol-http": "3.46.0",
-        "@aws-sdk/smithy-client": "3.46.0",
-        "@aws-sdk/types": "3.46.0",
-        "@aws-sdk/url-parser": "3.46.0",
-        "@aws-sdk/util-base64-browser": "3.46.0",
-        "@aws-sdk/util-base64-node": "3.46.0",
-        "@aws-sdk/util-body-length-browser": "3.46.0",
-        "@aws-sdk/util-body-length-node": "3.46.0",
-        "@aws-sdk/util-user-agent-browser": "3.46.0",
-        "@aws-sdk/util-user-agent-node": "3.46.0",
-        "@aws-sdk/util-utf8-browser": "3.46.0",
-        "@aws-sdk/util-utf8-node": "3.46.0",
+        "@aws-sdk/config-resolver": "3.47.0",
+        "@aws-sdk/fetch-http-handler": "3.47.0",
+        "@aws-sdk/hash-node": "3.47.0",
+        "@aws-sdk/invalid-dependency": "3.47.0",
+        "@aws-sdk/middleware-content-length": "3.47.0",
+        "@aws-sdk/middleware-host-header": "3.47.0",
+        "@aws-sdk/middleware-logger": "3.47.0",
+        "@aws-sdk/middleware-retry": "3.47.0",
+        "@aws-sdk/middleware-serde": "3.47.0",
+        "@aws-sdk/middleware-stack": "3.47.0",
+        "@aws-sdk/middleware-user-agent": "3.47.0",
+        "@aws-sdk/node-config-provider": "3.47.0",
+        "@aws-sdk/node-http-handler": "3.47.0",
+        "@aws-sdk/protocol-http": "3.47.0",
+        "@aws-sdk/smithy-client": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/url-parser": "3.47.0",
+        "@aws-sdk/util-base64-browser": "3.47.0",
+        "@aws-sdk/util-base64-node": "3.47.0",
+        "@aws-sdk/util-body-length-browser": "3.47.0",
+        "@aws-sdk/util-body-length-node": "3.47.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.47.0",
+        "@aws-sdk/util-defaults-mode-node": "3.47.0",
+        "@aws-sdk/util-user-agent-browser": "3.47.0",
+        "@aws-sdk/util-user-agent-node": "3.47.0",
+        "@aws-sdk/util-utf8-browser": "3.47.0",
+        "@aws-sdk/util-utf8-node": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.46.0.tgz",
-      "integrity": "sha512-iZqMLOYZ0/x19towcaqdL6zEfFRSPQKEZjbBKujeHlWNEi0ldlCt3a5R3V0nntoaPoa6bopUxRYj3VTLGD43Sg==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.47.0.tgz",
+      "integrity": "sha512-GVBeDm8XS2nSz2XS8cDJuudb3E4OWk9CCMzftjJBdFNacRx76irSBnerCGgHG1wwoaUD90lUCDbdY/IwVlS4Pg==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.46.0",
-        "@aws-sdk/credential-provider-node": "3.46.0",
-        "@aws-sdk/fetch-http-handler": "3.46.0",
-        "@aws-sdk/hash-node": "3.46.0",
-        "@aws-sdk/invalid-dependency": "3.46.0",
-        "@aws-sdk/middleware-content-length": "3.46.0",
-        "@aws-sdk/middleware-host-header": "3.46.0",
-        "@aws-sdk/middleware-logger": "3.46.0",
-        "@aws-sdk/middleware-retry": "3.46.0",
-        "@aws-sdk/middleware-sdk-sts": "3.46.0",
-        "@aws-sdk/middleware-serde": "3.46.0",
-        "@aws-sdk/middleware-signing": "3.46.0",
-        "@aws-sdk/middleware-stack": "3.46.0",
-        "@aws-sdk/middleware-user-agent": "3.46.0",
-        "@aws-sdk/node-config-provider": "3.46.0",
-        "@aws-sdk/node-http-handler": "3.46.0",
-        "@aws-sdk/protocol-http": "3.46.0",
-        "@aws-sdk/smithy-client": "3.46.0",
-        "@aws-sdk/types": "3.46.0",
-        "@aws-sdk/url-parser": "3.46.0",
-        "@aws-sdk/util-base64-browser": "3.46.0",
-        "@aws-sdk/util-base64-node": "3.46.0",
-        "@aws-sdk/util-body-length-browser": "3.46.0",
-        "@aws-sdk/util-body-length-node": "3.46.0",
-        "@aws-sdk/util-user-agent-browser": "3.46.0",
-        "@aws-sdk/util-user-agent-node": "3.46.0",
-        "@aws-sdk/util-utf8-browser": "3.46.0",
-        "@aws-sdk/util-utf8-node": "3.46.0",
+        "@aws-sdk/config-resolver": "3.47.0",
+        "@aws-sdk/credential-provider-node": "3.47.0",
+        "@aws-sdk/fetch-http-handler": "3.47.0",
+        "@aws-sdk/hash-node": "3.47.0",
+        "@aws-sdk/invalid-dependency": "3.47.0",
+        "@aws-sdk/middleware-content-length": "3.47.0",
+        "@aws-sdk/middleware-host-header": "3.47.0",
+        "@aws-sdk/middleware-logger": "3.47.0",
+        "@aws-sdk/middleware-retry": "3.47.0",
+        "@aws-sdk/middleware-sdk-sts": "3.47.0",
+        "@aws-sdk/middleware-serde": "3.47.0",
+        "@aws-sdk/middleware-signing": "3.47.0",
+        "@aws-sdk/middleware-stack": "3.47.0",
+        "@aws-sdk/middleware-user-agent": "3.47.0",
+        "@aws-sdk/node-config-provider": "3.47.0",
+        "@aws-sdk/node-http-handler": "3.47.0",
+        "@aws-sdk/protocol-http": "3.47.0",
+        "@aws-sdk/smithy-client": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/url-parser": "3.47.0",
+        "@aws-sdk/util-base64-browser": "3.47.0",
+        "@aws-sdk/util-base64-node": "3.47.0",
+        "@aws-sdk/util-body-length-browser": "3.47.0",
+        "@aws-sdk/util-body-length-node": "3.47.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.47.0",
+        "@aws-sdk/util-defaults-mode-node": "3.47.0",
+        "@aws-sdk/util-user-agent-browser": "3.47.0",
+        "@aws-sdk/util-user-agent-node": "3.47.0",
+        "@aws-sdk/util-utf8-browser": "3.47.0",
+        "@aws-sdk/util-utf8-node": "3.47.0",
         "entities": "2.2.0",
         "fast-xml-parser": "3.19.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/config-resolver": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.46.0.tgz",
-      "integrity": "sha512-R7YGDhvVE1VIS7uyjG3rZE1nrRu/+YVBq/pPlq5f4Tis3EoUooPfr5yYOVAuZI1CGsgycbCi6jnaqLGIfxUFmQ==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.47.0.tgz",
+      "integrity": "sha512-D3YV/hIVaUOHDVpLCwZGOyjSdQpxOVKnRPWT++kR6W0r5WC9F4tEtVCYwMnFRTVhOH87VvcMG/dkT5J4gTAgtQ==",
       "requires": {
-        "@aws-sdk/signature-v4": "3.46.0",
-        "@aws-sdk/types": "3.46.0",
-        "@aws-sdk/util-config-provider": "3.46.0",
+        "@aws-sdk/signature-v4": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/util-config-provider": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/credential-provider-env": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.46.0.tgz",
-      "integrity": "sha512-dBCyVBJ1nVi+lvM1jV6LFw8FpGjdeCglLMTmZUxJLBMh/Lp+GWtnGxd7u38WnH5gxKC4xLnYj9zP1t0ha1tGzQ==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.47.0.tgz",
+      "integrity": "sha512-x5FctbVUkr//KbjDm8UFFZ7caEl0O1E3vDOxezzZ4yUX4EraKRuYKO1dZIAGNBbNzSBv5simpqVxIXNuGyK9zw==",
       "requires": {
-        "@aws-sdk/property-provider": "3.46.0",
-        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/property-provider": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/credential-provider-imds": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.46.0.tgz",
-      "integrity": "sha512-nQidNDq6mjas/wFOi9XvHkvNmzM/XdSB/eRh6CH+wQeb8RjAlGm2Ivg0mpz/iIxjPXDIduW8aI/gFU3+3um6CQ==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.47.0.tgz",
+      "integrity": "sha512-GKfl8O/5Ywnn6/0KfsXopXKrGF31MWCBivISAbubN08X5Up7sQoJPAaDZ5xsi389yZ7+fdTCLKwOyrxobIsGLA==",
       "requires": {
-        "@aws-sdk/node-config-provider": "3.46.0",
-        "@aws-sdk/property-provider": "3.46.0",
-        "@aws-sdk/types": "3.46.0",
-        "@aws-sdk/url-parser": "3.46.0",
+        "@aws-sdk/node-config-provider": "3.47.0",
+        "@aws-sdk/property-provider": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/url-parser": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.46.0.tgz",
-      "integrity": "sha512-D+3YLWzCaFUUcbLHAsJIoaI8AhoSpIl3c0a3spVN64f+V1XtwunbJO6VXsIF78RLe0kTP7IA/Rey86ydQVeqcw==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.47.0.tgz",
+      "integrity": "sha512-h0VWqSdpDYjOMVJRmBXcVFW1+znXMGPmp2fXIg/1dgNkgbdstknFEwUXbgzmrVmE33Wc2UNpQYmnn3lvLUo85Q==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.46.0",
-        "@aws-sdk/credential-provider-imds": "3.46.0",
-        "@aws-sdk/credential-provider-sso": "3.46.0",
-        "@aws-sdk/credential-provider-web-identity": "3.46.0",
-        "@aws-sdk/property-provider": "3.46.0",
-        "@aws-sdk/shared-ini-file-loader": "3.46.0",
-        "@aws-sdk/types": "3.46.0",
-        "@aws-sdk/util-credentials": "3.46.0",
+        "@aws-sdk/credential-provider-env": "3.47.0",
+        "@aws-sdk/credential-provider-imds": "3.47.0",
+        "@aws-sdk/credential-provider-sso": "3.47.0",
+        "@aws-sdk/credential-provider-web-identity": "3.47.0",
+        "@aws-sdk/property-provider": "3.47.0",
+        "@aws-sdk/shared-ini-file-loader": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/util-credentials": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.46.0.tgz",
-      "integrity": "sha512-TrlGFBpIEHy7SnFOL8bE4IUC1Albxg1aSYgU92dzjGe1HhUSOzFABZhqwzfoo/xTCuS/DnA+2aTVD+hRR9t1Mw==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.47.0.tgz",
+      "integrity": "sha512-38T8CK7aUI7Uca3Wu686c6OAaLCfvmIPteiTyRQDr+GA9ElJo5d6bONc2ICibLzV7OGqgP/a7wPONnGPEe3VzA==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.46.0",
-        "@aws-sdk/credential-provider-imds": "3.46.0",
-        "@aws-sdk/credential-provider-ini": "3.46.0",
-        "@aws-sdk/credential-provider-process": "3.46.0",
-        "@aws-sdk/credential-provider-sso": "3.46.0",
-        "@aws-sdk/credential-provider-web-identity": "3.46.0",
-        "@aws-sdk/property-provider": "3.46.0",
-        "@aws-sdk/shared-ini-file-loader": "3.46.0",
-        "@aws-sdk/types": "3.46.0",
-        "@aws-sdk/util-credentials": "3.46.0",
+        "@aws-sdk/credential-provider-env": "3.47.0",
+        "@aws-sdk/credential-provider-imds": "3.47.0",
+        "@aws-sdk/credential-provider-ini": "3.47.0",
+        "@aws-sdk/credential-provider-process": "3.47.0",
+        "@aws-sdk/credential-provider-sso": "3.47.0",
+        "@aws-sdk/credential-provider-web-identity": "3.47.0",
+        "@aws-sdk/property-provider": "3.47.0",
+        "@aws-sdk/shared-ini-file-loader": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/util-credentials": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/credential-provider-process": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.46.0.tgz",
-      "integrity": "sha512-uW2+NgsqAJmQDQ6Y5t+U6E3LjLTEc06FCtJZIdYmfSGnsZoVH26DDIDg92G1ptFF8AzV26aypF2kjiRVRhIwDQ==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.47.0.tgz",
+      "integrity": "sha512-uk/u9tCzsgrYx9V6GtGlp6xkbblyF0auofxKIEyr2xIFQAtfa9GhCAP1F9bMbH9LcdF3pYhGI5rT3FCBuBbdmg==",
       "requires": {
-        "@aws-sdk/property-provider": "3.46.0",
-        "@aws-sdk/shared-ini-file-loader": "3.46.0",
-        "@aws-sdk/types": "3.46.0",
-        "@aws-sdk/util-credentials": "3.46.0",
+        "@aws-sdk/property-provider": "3.47.0",
+        "@aws-sdk/shared-ini-file-loader": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/util-credentials": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.46.0.tgz",
-      "integrity": "sha512-y3zv6FtaEu1cjtun6vQ1S/2aya70cPjCcoQhSrsH9TDYXp/ZRk4PN6xdVGGpkZX2kZhowGU5DvhOGK48IqrNZg==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.47.0.tgz",
+      "integrity": "sha512-isM2AKsgz/8mWP4mAAZZ0h4dMx2cNXu7mwNVl0XICV0JQlMA2CYcC9UfQ34NtCsZUY+gjhU2A001Ai9yJDispg==",
       "requires": {
-        "@aws-sdk/client-sso": "3.46.0",
-        "@aws-sdk/property-provider": "3.46.0",
-        "@aws-sdk/shared-ini-file-loader": "3.46.0",
-        "@aws-sdk/types": "3.46.0",
-        "@aws-sdk/util-credentials": "3.46.0",
+        "@aws-sdk/client-sso": "3.47.0",
+        "@aws-sdk/property-provider": "3.47.0",
+        "@aws-sdk/shared-ini-file-loader": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/util-credentials": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/credential-provider-web-identity": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.46.0.tgz",
-      "integrity": "sha512-VUNTS9HjwLRmS2OQ+i4tqVJBUpk/DjIT0sWUDnKBcC6UCyGOkVmBVisCvUHpwyCLCgYbCvTab1SfrJ8dZsN83w==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.47.0.tgz",
+      "integrity": "sha512-Tz17aDOuQv/lIRHuc/cbCS902QCpGakcy4MBxDPj1g5ccozrJC7IniS7OB3X4ghberggxx/4raWjNToNqtfobg==",
       "requires": {
-        "@aws-sdk/property-provider": "3.46.0",
-        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/property-provider": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/eventstream-marshaller": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-marshaller/-/eventstream-marshaller-3.46.0.tgz",
-      "integrity": "sha512-R6dDgiiAUDxss0rYpkOmSGQAtZNM66WNoR6UYWdEGU4rrapP5oT8z2N2cwv3ZuYsPESwXRu0D3S4jUSoIcxdqw==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-marshaller/-/eventstream-marshaller-3.47.0.tgz",
+      "integrity": "sha512-No8Kv7WOMpVUpagAYtfwmnQ/vGGXNix2X7FgBzIlsg490WIdUDhRLPi2Mm8jFKojKrdFA0L5QUktkHSBsz44eA==",
       "requires": {
         "@aws-crypto/crc32": "2.0.0",
-        "@aws-sdk/types": "3.46.0",
-        "@aws-sdk/util-hex-encoding": "3.46.0",
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/util-hex-encoding": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/eventstream-serde-browser": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.46.0.tgz",
-      "integrity": "sha512-c/pt2uH6n5rkaTlML0SHEepK6+L9TWgxFNy2+zAtWaHBCUyhTyv49H5jFaZOGWx4HkL+GzQqYfd85xHp362kTw==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.47.0.tgz",
+      "integrity": "sha512-F6kksTyIijSU7lxr0Hec80K67aoHZoo6VrCNRzCRme6aVWkkg5Zn7+dYOuwUOUM33gWPnbYk4EJsnfiMnuzt2w==",
       "requires": {
-        "@aws-sdk/eventstream-marshaller": "3.46.0",
-        "@aws-sdk/eventstream-serde-universal": "3.46.0",
-        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/eventstream-marshaller": "3.47.0",
+        "@aws-sdk/eventstream-serde-universal": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/eventstream-serde-config-resolver": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.46.0.tgz",
-      "integrity": "sha512-I9EcaP331MhJ9jCdKoJRB3hLzRS1+k/Z0qNl6Q/w3QiRvV2ujFcUkFOC4Po/ZYwqX00t4G1RVRlLYpNEGpLwDQ==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.47.0.tgz",
+      "integrity": "sha512-UrWoaWGEidrlzIFk39RnzNmF5ssFYflIOjmJS8AO9y6OUNf2jWZ6W0HtrjBYmgBFmeFZxDH16FZHAhLsA6ouVA==",
       "requires": {
-        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/types": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/eventstream-serde-node": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.46.0.tgz",
-      "integrity": "sha512-gU6GrZPYAbhUXvWQg/TZywpefaJHQ7Q4HskJGJWbwXEvsIGabpoY2NIbjiHfFsBxY3/6p0fxeQDoGQHgsGzw3w==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.47.0.tgz",
+      "integrity": "sha512-o9aL2nkpTjkHDA1A6wl50hsZHV+95aga0KyB7v1G0TPpLRHUvCELNiiK3G/1eO3LSgqoshu1w2vXi4JjjAeqlQ==",
       "requires": {
-        "@aws-sdk/eventstream-marshaller": "3.46.0",
-        "@aws-sdk/eventstream-serde-universal": "3.46.0",
-        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/eventstream-marshaller": "3.47.0",
+        "@aws-sdk/eventstream-serde-universal": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/eventstream-serde-universal": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.46.0.tgz",
-      "integrity": "sha512-sCwmAeotYun6q3o1KHeF7nYdHu78tOdjRSSoPCT10Ba+3ZzYaHNGWP+kpw6v1JTIkxmQIIqe4EMwtJ4xcOv0hw==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.47.0.tgz",
+      "integrity": "sha512-vi7e1XB66OK7If/ZvMuxNjl0bb/SFJSs2iW8q88btaVZHqfmUbcVDd0I/vJ7N32F0cwVVSxM+pEXRLg3hwYdIw==",
       "requires": {
-        "@aws-sdk/eventstream-marshaller": "3.46.0",
-        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/eventstream-marshaller": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/fetch-http-handler": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.46.0.tgz",
-      "integrity": "sha512-uOfdwbUCG+2LQ4iMkxD/izlzjnIrB5P5HtH7L5w1EFIsdxDXeFnnql0FaEcOvaEEg2rs9z0t+oLwMJZnNNtqAg==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.47.0.tgz",
+      "integrity": "sha512-FSQ5qQkHmCNAgjO2E89vV4QAN66EnHK8sTh4eH55UU0+9/h85g0uMTLMovoEN5Jk+h6AmPCbeq9i+HcPJTmWEQ==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.46.0",
-        "@aws-sdk/querystring-builder": "3.46.0",
-        "@aws-sdk/types": "3.46.0",
-        "@aws-sdk/util-base64-browser": "3.46.0",
+        "@aws-sdk/protocol-http": "3.47.0",
+        "@aws-sdk/querystring-builder": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/util-base64-browser": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/hash-blob-browser": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.46.0.tgz",
-      "integrity": "sha512-kCLzwH84gIQf6UW5WjgHKcMUfMYrNvB7w9v1GM5Hj4BITNpHbEo51EBKOpOzXfzy1J/kNpmET1TQENKK6a+nmw==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.47.0.tgz",
+      "integrity": "sha512-6rL4cy3XWSm89/lKZ1ip15mkTe5GXmTnQJTzwcDrtxbpZXeIsEDkeNPqNW9jGerWnMYW04SDxGek7dIDjIpVhg==",
       "requires": {
-        "@aws-sdk/chunked-blob-reader": "3.46.0",
-        "@aws-sdk/chunked-blob-reader-native": "3.46.0",
-        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/chunked-blob-reader": "3.47.0",
+        "@aws-sdk/chunked-blob-reader-native": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/hash-node": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.46.0.tgz",
-      "integrity": "sha512-rABF9k5uSJdqmwBeYnu+2+iWEmPNVsoBy9bwLvEmGfh557wAwh3dL5IDf+NiIFrd8GTOF/2HV1477XXBl15C0g==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.47.0.tgz",
+      "integrity": "sha512-OqLS/WweCBJz4BwO+EPF1yDeDo8YXXavY/vXElX6reb9+xew9TqmHoFSlFSR8GXkPU7SO+YnlOtmikpMz6fExQ==",
       "requires": {
-        "@aws-sdk/types": "3.46.0",
-        "@aws-sdk/util-buffer-from": "3.46.0",
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/util-buffer-from": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/hash-stream-node": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.46.0.tgz",
-      "integrity": "sha512-Q67LTIJG1Pq55uFKV2glQT3PN3nxit2x86BM0pUPKJrTVP+rPDgSC9jWaSXZwlj2EmwGrtz1eS8929zKCUBsOg==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.47.0.tgz",
+      "integrity": "sha512-VGCp0WEhMVvP+UBQDkzWgaqWvObS95cPu8mA96+H55dofuGWy9C1qib6wBvs5O+S/fc89ntCyBODeA0j/TAneg==",
       "requires": {
-        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/types": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/invalid-dependency": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.46.0.tgz",
-      "integrity": "sha512-KumWtDstAKpKRQbHA95AeHpBNtxCXHVbUk+nFAiXcBP281yEalUbyK0W5Q2bDl26L3z6zHodg3OJllHYavJKMg==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.47.0.tgz",
+      "integrity": "sha512-D2n0RA0o8WyFqPuwbVks177KasNK0bcJn+Fp6GzopSwSXQctULidm7S9pDS9fQW9TZW8xREeHhEyRgmstKc+PQ==",
       "requires": {
-        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/types": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/is-array-buffer": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.46.0.tgz",
-      "integrity": "sha512-HcQtJgZDQgo7ivD79GF82pTf+zYGjsgzKG7lkUBEetSfkV0W8h6XfhN6DmuYQuCcu1Pt9IkN7haYNPiPdfDhvg==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.47.0.tgz",
+      "integrity": "sha512-vm3rjUo9EYjLiog3OxGu+f0CdFjTooO2mg5bGb13Xv/2jpg6Z573Skms8nPEaF+ULJWJvobdK+yGw8r4w22cLA==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/md5-js": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.46.0.tgz",
-      "integrity": "sha512-2Ylg5fzOZpLGB47zR+ntroaZrMQp/E/nt+bqULqwQYVnA6+EN6+VDD4dKF3niFVIZcY1btcnMbshUJ4MnNjhcg==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.47.0.tgz",
+      "integrity": "sha512-Pwe0fv1K5ivQjc9ONcXoz0cEPpMcs+9JGb6LjtE+nPGlUYaEEFTeaWqUk3tQhvvznegWqBPzd+29w8GWQ5Fqmg==",
       "requires": {
-        "@aws-sdk/types": "3.46.0",
-        "@aws-sdk/util-utf8-browser": "3.46.0",
-        "@aws-sdk/util-utf8-node": "3.46.0",
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/util-utf8-browser": "3.47.0",
+        "@aws-sdk/util-utf8-node": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-apply-body-checksum": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-apply-body-checksum/-/middleware-apply-body-checksum-3.46.0.tgz",
-      "integrity": "sha512-PAss3dfIKmdpDyGNO6SaQLZvN8nytWGyjG/C+oPB8dW0kPJEf4wIMUAZbW3bqppwoe+bqAWt58v+Mw6XK4DZxw==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-apply-body-checksum/-/middleware-apply-body-checksum-3.47.0.tgz",
+      "integrity": "sha512-6Ge7Jf+obPuHDtaPqGtpgFE9fAGirkGsL4uXAojzLr5sQPnY905uiq6/99ewH+WLm02z8sNC/Z2vnxkiAix3Ow==",
       "requires": {
-        "@aws-sdk/is-array-buffer": "3.46.0",
-        "@aws-sdk/protocol-http": "3.46.0",
-        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/is-array-buffer": "3.47.0",
+        "@aws-sdk/protocol-http": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.46.0.tgz",
-      "integrity": "sha512-o5ryy1xMSokFI9tJY3zsX5pSk4/Wl21Jnz+JIiwcRinIZF3NvFz3b4eKHQn4FpNX5PvBrSHCk46drMtXB2oNyw==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.47.0.tgz",
+      "integrity": "sha512-u4i9Jk/j7QNseDZ2pzr3+XSjLerjcIqa8CGI+YcMEeMVQohQLbeNSiWftjkpaV+X2igI/4RKlgCjtiixTTsXMg==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.46.0",
-        "@aws-sdk/types": "3.46.0",
-        "@aws-sdk/util-arn-parser": "3.46.0",
-        "@aws-sdk/util-config-provider": "3.46.0",
+        "@aws-sdk/protocol-http": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/util-arn-parser": "3.47.0",
+        "@aws-sdk/util-config-provider": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-content-length": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.46.0.tgz",
-      "integrity": "sha512-Vf17vKAZ9n2ZlkMoHmCXMHAJegw3djC8qxe2sGdHSGyozfJNpA77ec32ldLvBtQ82LPmSaqdhcbP0/oYCalnzA==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.47.0.tgz",
+      "integrity": "sha512-xLz7BOYpb4rDsxOzyo5v7zPPI1F6vP+S19zpGcBWCg9csIOrbwSTrtwU+yOAfq7ZG+GSVxWnvMEsyqm362VF8Q==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.46.0",
-        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/protocol-http": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-expect-continue": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.46.0.tgz",
-      "integrity": "sha512-AGYg2B2WJJlj/VfaqGcxS5hRKkyGo4kVTeEYxxoVpg1FziaoAwcUEehAZSfHL9bVffXr+pIL7VFz5GppLWALYg==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.47.0.tgz",
+      "integrity": "sha512-Pi/HaBzatz04o3QtmgWMTnDHYM73XAo6JzHAzlA9LZP0AkB2W34lD0i9mfq+kOqgepfEOnAf2QcE7EX1XfhWPA==",
       "requires": {
-        "@aws-sdk/middleware-header-default": "3.46.0",
-        "@aws-sdk/protocol-http": "3.46.0",
-        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/middleware-header-default": "3.47.0",
+        "@aws-sdk/protocol-http": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-header-default": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-3.46.0.tgz",
-      "integrity": "sha512-HutbKluZuk4hm2RT0lE2XmO8UN8Fs8jQ+A5u3TNYxJeX4NpatQ5Nw7b3GwTe9SVOQ0l1iMjtrYvM8gfbjH00dQ==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-3.47.0.tgz",
+      "integrity": "sha512-zHtGb5GUCaOJV6fmwSdnKHXcMPcjtBw1FThrht9MQs9wcQE2iV3T6oUSIa1NhT2jGyjm86JKor5XPV5hG/ecsw==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.46.0",
-        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/protocol-http": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-host-header": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.46.0.tgz",
-      "integrity": "sha512-I+WsUzpyzS9l5Dt64kyp7v+9KeYPOCviYmVw2kM1EZRdAeo+jiCRxU5LnDJ9ORxfRwGcEmQV7xb4UpqXcn2N6Q==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.47.0.tgz",
+      "integrity": "sha512-jkCoH7wHTWo5UduB46e4A71Uj5EKSYf/44Sxf+/PGyOaGW+SbP9nkjdjyWKB5p84WmvhayZLed/qUJgJpTrpGA==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.46.0",
-        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/protocol-http": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-location-constraint": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.46.0.tgz",
-      "integrity": "sha512-sn9A5+LKYkXfjMwDfIb01ru8z/1t+ALERvIkILTK0YuzNRIJLPMumiuY5XhKEbte0z4+ie5yytcfW9kU2NUA6Q==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.47.0.tgz",
+      "integrity": "sha512-ebO7W0G6m/Zo5Zkiud6HPU6NDSkgk4MiW8fOX+/4b0Vol55XrryMWSzS+t6+L8jIC3tqIXmaHTZbhUP3LXhIWA==",
       "requires": {
-        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/types": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-logger": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.46.0.tgz",
-      "integrity": "sha512-xkB98tfZc1pSeks0a7jagYIVHxJfoxHX7wcASzBa3IjyodZpSqDW392edF9c3kSCv6G6PGRbG+F1F6j7ZTVpRQ==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.47.0.tgz",
+      "integrity": "sha512-cK1q+43n2jh/j7jTuFIez7u5k56i2YnjP3DRlh12PfiXiA9V39mfdIu59XHERtE+wJlAyHUq1lYix83CMXOWfQ==",
       "requires": {
-        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/types": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-retry": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.46.0.tgz",
-      "integrity": "sha512-YkNNs2dUcriLwy4pYG7nfa850tD8dtFUeE/IQ+YBMbWDedT31UFkCfHUdjBK1GFbIv+G1N+ZVGBCkWq1OuhKXw==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.47.0.tgz",
+      "integrity": "sha512-AHIxtUFNWSLNZjpgR0Jfx+6X78qPJjmyrfv8S5MVW1uURZK14aepV+0JyGBkjFPJVu0yQzcIlvIgKO20e3zQwQ==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.46.0",
-        "@aws-sdk/service-error-classification": "3.46.0",
-        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/protocol-http": "3.47.0",
+        "@aws-sdk/service-error-classification": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
         "tslib": "^2.3.0",
         "uuid": "^8.3.2"
       }
     },
     "@aws-sdk/middleware-sdk-s3": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.46.0.tgz",
-      "integrity": "sha512-5xj+9Jaur0oVZerabvD26sfoF0a158BXPrwkKLM4nm1TWJSK4JMbT0nxryzRrOylt5I86W9CRJeHVLFTpV3QKg==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.47.0.tgz",
+      "integrity": "sha512-ysnDyfNvZKfnUI5eG25/GLGpe98tw6odAzNIylT4lLBt9ElyvYc/QCKgVb5uFSqRvshsk0gQPmdX0odsV+43ng==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.46.0",
-        "@aws-sdk/signature-v4": "3.46.0",
-        "@aws-sdk/types": "3.46.0",
-        "@aws-sdk/util-arn-parser": "3.46.0",
+        "@aws-sdk/protocol-http": "3.47.0",
+        "@aws-sdk/signature-v4": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/util-arn-parser": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-sdk-sts": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.46.0.tgz",
-      "integrity": "sha512-JcLwMBqg0ZsHU79e4VixU7e2YI+pktRuI9HXKc4Aoic+h65TXOzB3KjAllweUNjQtc6ZZvqYdd9WJ6PFs1X93A==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.47.0.tgz",
+      "integrity": "sha512-DbXxMeGmnxjOt6fk2UHuQQmuRILnHr5mj6e3xwiYmkg7ClM2fmP3vy94Q98RgDtpEwlyb6yHCONiWP4iXExoug==",
       "requires": {
-        "@aws-sdk/middleware-signing": "3.46.0",
-        "@aws-sdk/property-provider": "3.46.0",
-        "@aws-sdk/protocol-http": "3.46.0",
-        "@aws-sdk/signature-v4": "3.46.0",
-        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/middleware-signing": "3.47.0",
+        "@aws-sdk/property-provider": "3.47.0",
+        "@aws-sdk/protocol-http": "3.47.0",
+        "@aws-sdk/signature-v4": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-serde": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.46.0.tgz",
-      "integrity": "sha512-5M56VUm/stsSabauHxFrv1BSoH0VPyMB1V4vewAD3cp5YGiUpChYxjhcBbzi0QvI65HLxa6nLedwrE+g1uVJ1Q==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.47.0.tgz",
+      "integrity": "sha512-MYJqW9xoq//FHa6A6drZ48Wswy8vuFrnbTsKK45AsIKs8kdscYnlWC8s7ndmYrMoT4235TRi8QgcjLC8WMIu9Q==",
       "requires": {
-        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/types": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-signing": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.46.0.tgz",
-      "integrity": "sha512-wyv58cufJ2mWtpgfdMYs2ZPnyGadgnaZpWpdoVTpSte8PyUXjRiaR8dLkj84DWUurT6m1h7NEPIHgL6+W1Wwfg==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.47.0.tgz",
+      "integrity": "sha512-oDQ93PiP/90Kl7b3AcHLxsHtWNSxTSdYbJRu4mLb31jKobd2GmLc+tz7L8DpKRyv+fkbrf0Lxh/zLAwaaZdNfg==",
       "requires": {
-        "@aws-sdk/property-provider": "3.46.0",
-        "@aws-sdk/protocol-http": "3.46.0",
-        "@aws-sdk/signature-v4": "3.46.0",
-        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/property-provider": "3.47.0",
+        "@aws-sdk/protocol-http": "3.47.0",
+        "@aws-sdk/signature-v4": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-ssec": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.46.0.tgz",
-      "integrity": "sha512-rIgm3HBVrHu2hutNQFZSoJOV+I+wkO9qMKkBKLEpgA9CKsRRJ1IYM6iY+/27oQvG6soydJPy2IHLlmQRZg4WxQ==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.47.0.tgz",
+      "integrity": "sha512-Me/VHaFtG3OIgUPIVm59DZJfzWvBnj/WeUeJ1kyxecK/vC1GZriZrhGBHjrrJh1I7HWgRhE58NYdmjj9l0Bayg==",
       "requires": {
-        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/types": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-stack": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.46.0.tgz",
-      "integrity": "sha512-+3SmpYo12i9Gn7L/HEJqAv5+OieZL9zfXungFKr96rTpcvYDZWQblTP3tugBtvGV6V4tzvebMkUTWxBB6p+dhQ==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.47.0.tgz",
+      "integrity": "sha512-F2iwZMXERLTddIovCa7uQmrKXTu3O/Rbym/xKC51J1hnELoNudzIuNIdUQsnSfSIJBl0pB5najN1O2IHBcO/oQ==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-user-agent": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.46.0.tgz",
-      "integrity": "sha512-n9VEWlIXxbJXCr2IpocNJQUW7dhCdAcPKmxV0T5LZ/AygKsLvbWy40u2Qm9/eB1MYpqiheeb5MsY3UXxHgnOlg==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.47.0.tgz",
+      "integrity": "sha512-L0uYhbzXDXSYkvtSzLhpSqv/Hg0Wlwf0PPdYHqPmNJFrN+rigjxvu32e10lZj8JCsqX/tRlPULQdrn1mOvHeMg==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.46.0",
-        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/protocol-http": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/node-config-provider": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.46.0.tgz",
-      "integrity": "sha512-Hzz860d1GNZSSX74TywfUu125l8BT6JkJuKG0QDhuC+9xklNfC1hgziihldHu6xL7DzY5UKgjyzdNBQfqCqLbw==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.47.0.tgz",
+      "integrity": "sha512-YLv2CmM8CfedhtrqMhSoEtJenJlWWGCBOvhewXhEPMa+P/PKZ9HxsKdOTC/+lpuWhnD700fG6kFnn2R0kSQE4g==",
       "requires": {
-        "@aws-sdk/property-provider": "3.46.0",
-        "@aws-sdk/shared-ini-file-loader": "3.46.0",
-        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/property-provider": "3.47.0",
+        "@aws-sdk/shared-ini-file-loader": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/node-http-handler": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.46.0.tgz",
-      "integrity": "sha512-SqeKskt47u/ZIeN5b6lmjOAx0yLiY/WDQ6N9Z6LRJCYiSZ7oHflA1jPWkX20qWOKioa2iHBVTNNX2lu8yFkWbg==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.47.0.tgz",
+      "integrity": "sha512-wZAU3BLLn/mmWR8bYIBdx+gcdwjO1KNNe7C6yXUwvFgClBjCxqR6C32k8CJ3eGiKulGgkBmX8DKGXIdqv0W7kw==",
       "requires": {
-        "@aws-sdk/abort-controller": "3.46.0",
-        "@aws-sdk/protocol-http": "3.46.0",
-        "@aws-sdk/querystring-builder": "3.46.0",
-        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/abort-controller": "3.47.0",
+        "@aws-sdk/protocol-http": "3.47.0",
+        "@aws-sdk/querystring-builder": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/property-provider": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.46.0.tgz",
-      "integrity": "sha512-e3Jcds7G1Hg5VDvwLox0HlQq4G2fvmkO1BRPvM8WfRGvxRNK40dqoelm2NMtbNK0KgFPIpKsGeX1UhZDt9Od9w==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.47.0.tgz",
+      "integrity": "sha512-S59dASvUxqepS9jTxoN9YrP1CTioYcbNLdg2VwFNglXNRekOP2sxyvtGxDE3oVc3ZgzEyq8+OWsReONf8Tdy4g==",
       "requires": {
-        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/types": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/protocol-http": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.46.0.tgz",
-      "integrity": "sha512-hKqHYEp/JDfOl5kZKp0CRgvbsg+c52Ss4KwuRoU9vA56VZ5TpfgHznajdme97xedsE40hnZeitv2BKEMbkYCqg==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.47.0.tgz",
+      "integrity": "sha512-Oz9iTfuMmpGVB8AGqJ4A1S8OmcAQlM4/f0QLHLp1Kcjnu7H3jysk3B7qWLgqxO7DwKEX4XU8AXohwQv1aXgI8Q==",
       "requires": {
-        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/types": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/querystring-builder": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.46.0.tgz",
-      "integrity": "sha512-YYGRK291ro+KR3TX0jjyGRdMGHn6D2CBD89oXj8tAV3djeMIpFSGDrEL+NKeJvp7aBNlEnQ9kSfzyQuzQVvJWA==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.47.0.tgz",
+      "integrity": "sha512-Ou5ipsOZgsMkSnA61Y5xRoOaxHX9vuqBlWL6iAppSonFanj73qrmymUY+AGUznDiUAxCWcvxdnPUIYDm5grwyg==",
       "requires": {
-        "@aws-sdk/types": "3.46.0",
-        "@aws-sdk/util-uri-escape": "3.46.0",
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/util-uri-escape": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/querystring-parser": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.46.0.tgz",
-      "integrity": "sha512-xxTnIXLbx4Jq16Utza7wh4HpPfVyCL0c+6NU2t+kXZ2sgOWhx2XAhShcZVbEkA/61UAMEIhyNBVE+z9OFz6X5g==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.47.0.tgz",
+      "integrity": "sha512-UQlLg7KDHQAQwS4lILE9wht+m3azXrNjWDAHeQqsG8mqCjvSCu5L9t3BBI+EO4dPb9CKa61fjtuzslxvpZdZ3w==",
       "requires": {
-        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/types": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/s3-request-presigner": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.46.0.tgz",
-      "integrity": "sha512-pnnjGf4agTr21i4jvAgxUWqy3LBwoOIkLLXCD/tCYgTzcmbf1q/gVu+09+GVGNlLyo0ONatNTfpdS2FJ7XNf9Q==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.47.0.tgz",
+      "integrity": "sha512-fz82XzgTg9SY/wdbgHdG/YNUim1VWL0sRC6K+801lVyXV8bh8cylgfFDt7Z2YZ/N5VgX9yk/NgiPejYs3e6FmA==",
       "requires": {
-        "@aws-sdk/middleware-sdk-s3": "3.46.0",
-        "@aws-sdk/protocol-http": "3.46.0",
-        "@aws-sdk/signature-v4": "3.46.0",
-        "@aws-sdk/smithy-client": "3.46.0",
-        "@aws-sdk/types": "3.46.0",
-        "@aws-sdk/util-create-request": "3.46.0",
-        "@aws-sdk/util-format-url": "3.46.0",
+        "@aws-sdk/middleware-sdk-s3": "3.47.0",
+        "@aws-sdk/protocol-http": "3.47.0",
+        "@aws-sdk/signature-v4": "3.47.0",
+        "@aws-sdk/smithy-client": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/util-create-request": "3.47.0",
+        "@aws-sdk/util-format-url": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/service-error-classification": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.46.0.tgz",
-      "integrity": "sha512-hFDh/qtvKX9xUPxjGiDvumKsoO/3+eL4hi6X3qWN8lHg49wixjwcwlCEPn9jhdFJ9TRXc20CgPxWv4+V96Yf/A=="
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.47.0.tgz",
+      "integrity": "sha512-15SEeOb+In/hEiSfEWYQvjuA5NeoWlh1iOt8aX4eQLqqIIr5DWyLsremTeWtNN3rIbJzU7yVHg5cv2xn3MJ8Wg=="
     },
     "@aws-sdk/shared-ini-file-loader": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.46.0.tgz",
-      "integrity": "sha512-Rp7Z1X23kvyRCziOxXu2PYCCPT5CQ5t8O4WoKrEkMT9Vqm2gluXOcCnL4iOpRkSRGEZT7lfe5OCM8ApNRTIHpQ==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.47.0.tgz",
+      "integrity": "sha512-yPl190HEyTNawkaOnGkG4zgY+dlXDvSx/RRMxsYoBycaU7V4dfYlXkVZDFe0hqnxw/s/aN7qKfzvEvRkrd9kcg==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/signature-v4": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.46.0.tgz",
-      "integrity": "sha512-qtI1t0CrEhVCxaezmmBpMe1WmQxdxho8oPiMEKWIUkkXQFg78Eg3jnXlLhjL4+MGHMqBB3mV7nGO6k8qu8H9rA==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.47.0.tgz",
+      "integrity": "sha512-b1JDXaBRNQ9niMz7Hj6XZ2OfDNT8+a+3fP+BxmFlaFPV++Huo1ClpimzFS8KjRBBrFltTOPPJnEfS+M4cBsnEQ==",
       "requires": {
-        "@aws-sdk/is-array-buffer": "3.46.0",
-        "@aws-sdk/types": "3.46.0",
-        "@aws-sdk/util-hex-encoding": "3.46.0",
-        "@aws-sdk/util-uri-escape": "3.46.0",
+        "@aws-sdk/is-array-buffer": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "@aws-sdk/util-hex-encoding": "3.47.0",
+        "@aws-sdk/util-uri-escape": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/smithy-client": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.46.0.tgz",
-      "integrity": "sha512-Dzx4CR+rOkr5hXbLhnOfnrPWmSs4O9BTjFWD+4oh+RTXq0It8g+fWZxPcdvRCDU4GjS9Gtbkw0f0pN3FMCEszQ==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.47.0.tgz",
+      "integrity": "sha512-rq1H//VJKopXgRJgso+BdFBD4hrssbFky1BuvXu7orIi8Wp7oS2LogKctqclX7THrXCNT6mzHaxvU6xEOWYUXg==",
       "requires": {
-        "@aws-sdk/middleware-stack": "3.46.0",
-        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/middleware-stack": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/types": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.46.0.tgz",
-      "integrity": "sha512-yhrkVVyv4RUt3KqDDyEayjBM5dRBtuS486THeqtSghUYNV7M/cW18TA3gdMC0pRGgUqfKrOysdBZjCyPrYNvuA=="
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.47.0.tgz",
+      "integrity": "sha512-ljxyrASkxCsgPXW/jRGGokNtjOql4RbzEl23HEliDmmETlKOrUKVDa2iqhnz5nvqVTc1MgOQv/dr9YBO1LHHIQ=="
     },
     "@aws-sdk/url-parser": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.46.0.tgz",
-      "integrity": "sha512-foMB0AC3QDy+KfvRxsMXvJQZXr9CMzdupcNIXwKRZog82tEEc09dVeUjuJrO4H+A2eK84SyawRfy+ow+LRqvqw==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.47.0.tgz",
+      "integrity": "sha512-BGfyYZgPvcJ+fW5+i29fy9IwG/2R3LYnWyZ85AFbE++8YcMueJhD7Sychh3mUINViCzjUTVC971m56ee9O9QLA==",
       "requires": {
-        "@aws-sdk/querystring-parser": "3.46.0",
-        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/querystring-parser": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-arn-parser": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.46.0.tgz",
-      "integrity": "sha512-MIeqH53/Z5x+uQ/EHs6zqkdBqdpGA8tA6l/mL1j8hRK6bSQEUTAVlPNgjp03qse1Fk94GJbJbjZ4C0R7Z4YM+g==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.47.0.tgz",
+      "integrity": "sha512-ilmTCowm/QyMYGn91Cf4E+hnco6th8CVbiLUIqgUHuZRtP0iXA9oInf7/FIqdLgt7+vzyg7wHpRFosTXQ+kfqQ==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-base64-browser": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.46.0.tgz",
-      "integrity": "sha512-oDlExDHYVOXsHFwFCA+CxZlGiHWeO53l0xoohpTIwGV6u48jED/4GrNM6iWVT6Vwd4skqtRMM41IHXjtiCtp/g==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.47.0.tgz",
+      "integrity": "sha512-mG6mCdWWzxdDNKmF4YAn4LH7DBdPfTH/eN8ZrkEWamx9goaO1odQz7p86bxMFe5qMHSPRMgGpCuQoJurg7E4cg==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-base64-node": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.46.0.tgz",
-      "integrity": "sha512-/ruNBm21Ptk+IGhwTphs8j5oDCjNIrUSipDoRtUuMGQR9TnNzup0e+sJDqP0BrKKM+tcvqEUhz+MScxbwJrwmg==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.47.0.tgz",
+      "integrity": "sha512-r2ym8kSeLR4m18TFM8M3IThkj3i0DvETF/kxPdfa2fHKL7Lq7bfUDJjzr0LmFhdy7iEEcjeLO1hyBklyCke1nQ==",
       "requires": {
-        "@aws-sdk/util-buffer-from": "3.46.0",
+        "@aws-sdk/util-buffer-from": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-body-length-browser": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.46.0.tgz",
-      "integrity": "sha512-OJgMlBv4gEdmHCdZO9htysz9GMw0mS7qB3I5CbZ2aBOM0NvmaU7nqI6zYCoEmGh0keq0CnMBlNZhBBAwtiKYqg==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.47.0.tgz",
+      "integrity": "sha512-1hHX3uXrl/XKYx2dEULDhtBeofQLHQhllUSbtxj/t8HBZtNhwTSXgb0jbZhPvUFCnzL5ag4znYzEyukLLxgwwQ==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-body-length-node": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.46.0.tgz",
-      "integrity": "sha512-jyD+2c7iaD4Aih93Fm4I183SbdhSy4FNmSlK49PctMVVF+QSpzQxAJvv/nTwq37Kb8orVvs+sgy2FF3lxfOUJg==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.47.0.tgz",
+      "integrity": "sha512-PGh5179ZEDS9kcUy1M0i5QiNMeVsCseXh152OT6rU/3yb0h9rozefED/DYEnW/UC0eQNDyj0mgEpT9R86e4S2w==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-buffer-from": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.46.0.tgz",
-      "integrity": "sha512-e3avbwAUULpPCk4ke9ctrhAwxcXvMv8FYymNJDEN7+9lqZ4XqAjPt+R+IEEFMEbWmIPeZ8TpLw3yuru1Z74iuA==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.47.0.tgz",
+      "integrity": "sha512-pANJWhIZ32RuQVwtqf2rqllZngZYW0dgOiDwCMCDjBOuhlrqCVs2cwOvDJp7SS5TUg6dt6powFC7UKRRjFMe1g==",
       "requires": {
-        "@aws-sdk/is-array-buffer": "3.46.0",
+        "@aws-sdk/is-array-buffer": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-config-provider": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.46.0.tgz",
-      "integrity": "sha512-KzzusGkvmb1uy3EItl+9YRxOOtjmU6iaAi9pBzHR2fiv13EMVNZrycVFPeGwz6LrsAEumKmTAZjR6c8BRbxtjw==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.47.0.tgz",
+      "integrity": "sha512-93JmYEtExWBlFM18yt7CuUCBf7WQGAjDEMuhy2sCmhgu+lRwicSCLkjEUFPUTxOv2QbU3HJV2CSKzpAjFAWrSA==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-create-request": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-create-request/-/util-create-request-3.46.0.tgz",
-      "integrity": "sha512-Fu42fGq9Jgu2s3PP008QDOomuWB1+MjOTei3YEKpnvhOV9MxgqA68WdCbbpKBR3y3E/3auwDbtSt4ddB0MFaMg==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-create-request/-/util-create-request-3.47.0.tgz",
+      "integrity": "sha512-EoJFV8l96rIABoVIRBSCO9UZavTkyiOcSAR0cdIiboNRQodSUJgiEtRhxAUbem59yX2ZL0I/bEHVLXa5HT8a+Q==",
       "requires": {
-        "@aws-sdk/middleware-stack": "3.46.0",
-        "@aws-sdk/smithy-client": "3.46.0",
-        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/middleware-stack": "3.47.0",
+        "@aws-sdk/smithy-client": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-credentials": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.46.0.tgz",
-      "integrity": "sha512-d5bDyCDVYi6ThBY8AntAKooExayFuLUnCXsDkmmWpHlp26JZv9s1/DsXR219ELgu8jIAWiID54HjfEYf8qa6Vw==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.47.0.tgz",
+      "integrity": "sha512-0I4Azt1C+xWORep3Qq/B6ZYoIL+fPCgqxYL7k3amW5yjkS4T/r0Md6mG41pb9CEHkbIYtQhzfhcUjqb1hNgIvg==",
       "requires": {
-        "@aws-sdk/shared-ini-file-loader": "3.46.0",
+        "@aws-sdk/shared-ini-file-loader": "3.47.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.47.0.tgz",
+      "integrity": "sha512-W5ZYzxU23h6F/2vf6H0BJOzV0UVaCzi9l4sN/00m0FfoGMylwSVeJ0dKMwhMAq5o8sdCSRfzHdvAsXj5TjtghQ==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-defaults-mode-node": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.47.0.tgz",
+      "integrity": "sha512-WSTXyAp51FaP0IGf2ZKS1iF7IZ+ct0q8qSBDp12frTIdJO2RZDTQftTq+RrOSj20LXnZi5rf0ICUOFJjomWg4w==",
+      "requires": {
+        "@aws-sdk/config-resolver": "3.47.0",
+        "@aws-sdk/credential-provider-imds": "3.47.0",
+        "@aws-sdk/node-config-provider": "3.47.0",
+        "@aws-sdk/property-provider": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-format-url": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.46.0.tgz",
-      "integrity": "sha512-Wae7sLWA29uy4TLLN8PjqR5DPmosqbFR9oARGCxegzFcha9adu88CD2Y9mU7zCF6fFymu/NHpNTEQkX+VdFX/w==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.47.0.tgz",
+      "integrity": "sha512-a7KXXHzFMthoNvwfBTV5bSr+7wNb+1B87/guPDqaWxtXXAh9iWuoJ4XJI6kV1Y2y/4kVR18fXmZH8SnV+wpJYw==",
       "requires": {
-        "@aws-sdk/querystring-builder": "3.46.0",
-        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/querystring-builder": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-hex-encoding": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.46.0.tgz",
-      "integrity": "sha512-A831jS32tbdjki4ihS0BIZ3HAi1gv2PtLmAjAW+PHVvBd0S4OpbQApKxKPu0w+NKsp9XQYfkEkeFKCcMqN1zhg==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.47.0.tgz",
+      "integrity": "sha512-94pkobzbyfasUTUOQSWOixo71ohEPGw2FHnTw/vQ28wQYVYJE8NaV2Z4MyeQlsxSvsthsE4D5u5i1uo+WKFzSQ==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-locate-window": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.46.0.tgz",
-      "integrity": "sha512-g6V/7mozjlP2HhwHHgGgoOvcNRJasIQjh7ClkCMrMilfthD4WNtkWfcAZQD+BaPKkSgj8MnIOFvFzqULGeNQXA==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.47.0.tgz",
+      "integrity": "sha512-ptZQQNDG4++Za8EEVs43rmKPnjnIvOnX0QvLQ5cc4Opu28CdYJL89tTt3rq5o+DgQhC+E5rYuLLdqTekYXXxJg==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-uri-escape": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.46.0.tgz",
-      "integrity": "sha512-drAHEt3YnI6H6NpiTFLFT8e75bOhaO94ZP+kqz/0hluQiKX47Pow3Ar3Diaf/CUMLctH0IX3AaN3T2ve5v19lQ==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.47.0.tgz",
+      "integrity": "sha512-4qxKb98t395h7dQWlD0iUMZpTH1JEPWdcNUCZtbVLwXy5lKzJOl4MPMwObdMhruMa9rgMEKwk6btaSzPK12KAw==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-user-agent-browser": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.46.0.tgz",
-      "integrity": "sha512-wwUh4H6+ur9akctoSgaz41J8JuRrOqey4aY68DmDQ0did3UjhRlbPD3xu0umXoPSgmtqQyl34oMPqCOfA70Z0Q==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.47.0.tgz",
+      "integrity": "sha512-T0MHvvdt98aDGjSnW1wZU0rTtsA/6zr8735ZHTF6ObEH8ZQ28RPTtD0eWO5pUWfReU8yQxDXhBhJK41/lOOtSA==",
       "requires": {
-        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/types": "3.47.0",
         "bowser": "^2.11.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-user-agent-node": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.46.0.tgz",
-      "integrity": "sha512-JCY8mKWPic0aXtz7amKXWyjbX8fhdOkRcgsCCnevOHc/7KOxwa97VnDT555GNQ76LO+cEDgYueHklUayV3u+IA==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.47.0.tgz",
+      "integrity": "sha512-aGft3RuO8vQyTFMR5tn4WMtjsVMA9WiPx9WCloheieXmlO7gtez9qr51GFYteBQq9lfdiY9PPj4uaOG21efSIg==",
       "requires": {
-        "@aws-sdk/node-config-provider": "3.46.0",
-        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/node-config-provider": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-utf8-browser": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.46.0.tgz",
-      "integrity": "sha512-zafI5Y7hRVC0vhJ77FPUyBckmpF2v2ZEKFC79AdwdFX11l7XNmq0hY/4CWVYeZ2L0Fyk0UV6eeKyk/TNdce0mg==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.47.0.tgz",
+      "integrity": "sha512-qOYj00VqTVyUVb9gndS9yGHB/tRuK7EPGFvnhRh4VEkwVymH8ywyoFntRhWS/hSrrcQp0W35iS+fJPqdQ1nGWg==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-utf8-node": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.46.0.tgz",
-      "integrity": "sha512-Uk9hQrWQowU4ymtSxrxiIp7GnBoZfkKGSeWDy2h/1Biaexq9FQclbgwa0ZhA5lKLDj/nUxnXoT/ZcY90mTdzzQ==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.47.0.tgz",
+      "integrity": "sha512-zbcF4zYPta/5tsogtRQ99uPyEB2WGaOyybRaS4cGPhtLiRdA/1wcwmld8ctEaCCf4m4wr2Vu6U9v3SnY92V55w==",
       "requires": {
-        "@aws-sdk/util-buffer-from": "3.46.0",
+        "@aws-sdk/util-buffer-from": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-waiter": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.46.0.tgz",
-      "integrity": "sha512-rn1bf9whuHfarNTFSRnFIupRlfN+L28hRZL8PClgyxa0WqpzG0goN6M+opuYnbKrTazyqktxpUTg/fHHoQiveA==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.47.0.tgz",
+      "integrity": "sha512-ED8Q7v8Z23NimTcPTK+VN2+NcTvVNLpm5+FzqCiXShZ6tM088e0fzwhyIVTejgbc0mvJE7QfEbR9ZSbr3a1zcw==",
       "requires": {
-        "@aws-sdk/abort-controller": "3.46.0",
-        "@aws-sdk/types": "3.46.0",
+        "@aws-sdk/abort-controller": "3.47.0",
+        "@aws-sdk/types": "3.47.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/xml-builder": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.46.0.tgz",
-      "integrity": "sha512-CeqtrNiyA4c9GeX5HJNTrMohHKm6haEeX8Nzkc//whRgXb9UEj++JMd5SxCTmO3TEIO1QmmoScSMiiywOeoDiQ==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.47.0.tgz",
+      "integrity": "sha512-C9929miRb1nb8oVUwQiQ42zCbC521qenCMUavyN921hnq1CUe9nLcBBzA6mHn4Vk3fz4orRHzx7vv91hPCZ3+Q==",
       "requires": {
         "tslib": "^2.3.0"
       }
@@ -1230,9 +1260,9 @@
       "dev": true
     },
     "@nimbella/nimbella-deployer": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-3.1.8.tgz",
-      "integrity": "sha512-imK2C+FUB8ZnvEdn1IBh8+mL9elE/iX1aZAH1eJEc9KUEg0NW/SucvlGJxcFu0oJ4yVm5gC0/Ovvkt1ekVIK+w==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-3.1.9.tgz",
+      "integrity": "sha512-0DJQTUJuKeH+LaAtdzZqLWwtDoC7FSlMrhFUvaRPHJRY4avylAryZ0getSRd+lfWYlgS7HsSHV3sUE876xeVwA==",
       "requires": {
         "@nimbella/sdk": "^1.3.5",
         "@nimbella/storage": "^0.0.7",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@adobe/aio-cli-plugin-runtime": "github:nimbella/aio-cli-plugin-runtime#v2021-11-19-1",
     "@adobe/aio-lib-core-config": "^2.0.0",
     "@adobe/aio-lib-runtime": "^2.0.0",
-    "@nimbella/nimbella-deployer": "^3.1.8",
+    "@nimbella/nimbella-deployer": "^3.1.9",
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-autocomplete": "^0.3.0",

--- a/src/NimBaseCommand.ts
+++ b/src/NimBaseCommand.ts
@@ -61,6 +61,7 @@ export interface NimLogger {
   displayError: (msg: string, err?: Error) => void
   logJSON: (entity: Record<string, unknown>) => void
   logTable: (data: Record<string, unknown>[], columns: Record<string, unknown>, options: Record<string, unknown>) => void
+  logOutput: (json: any, msgs: string[]) => void
 }
 
 // Wrap the logger in a Feedback for using the deployer API.
@@ -89,6 +90,7 @@ export class CaptureLogger implements NimLogger {
   tableOptions: Record<string, unknown> // The options definition needed to format the table with cli-ux
   captured: string[] = [] // Captured line by line output (flowing via Logger.log)
   entity: Record<string, unknown> // An output entity if that kind of output was produced
+
   log(msg = '', ...args: any[]): void {
     const msgs = String(msg).split('\n')
     for (const msg of msgs) {
@@ -120,6 +122,11 @@ export class CaptureLogger implements NimLogger {
     this.tableColumns = columns
     this.tableOptions = options
   }
+
+  logOutput(json: Record<string, unknown>, msgs: string[]): void {
+    this.entity = json
+    this.captured = msgs
+  }
 }
 
 // Test if a supplied logger is a CaptureLogger
@@ -145,7 +152,7 @@ class AioCommand extends Command {
 // The base for all our commands, including the ones that delegate to aio.  There are methods designed to be called from the
 // kui repl as well as ones that implement the oclif command model.
 export abstract class NimBaseCommand extends Command implements NimLogger {
-  // Superclass must implement for dual invocation by kui and oclif.  Arguments are
+  // Subclass must implement for dual invocation by kui and oclif.  Arguments are
   //  - rawArgv -- what the process would call argv
   //  - argv -- what oclif calls argv and kui calls argvNoOptions (rawArgv with flags stripped out)
   //  - args -- the args (oclif's argv) reorganized as a dictionary based on assigning names (oclif calls this 'args')
@@ -160,6 +167,9 @@ export abstract class NimBaseCommand extends Command implements NimLogger {
   // Usage model for when running with kui
   usage: Record<string, any>
 
+  // Saved value of the --json flag from the command invocation
+  useJSON: boolean
+
   // A general way of running help from a command.  Use _help in oclif and helpHelper in kui
   doHelp(): void {
     if (helpHelper && this.usage) {
@@ -170,29 +180,59 @@ export abstract class NimBaseCommand extends Command implements NimLogger {
   }
 
   // Implement logJSON for logger interface.  Since this context assumes textual output we just stringify the JSON
-  logJSON(entity: Record<string, unknown>): void {
+  // Behavior is not conditioned on the useJSON variable.
+  logJSON(entity: any): void {
     debugJSON('JSON logging invoked')
     const output = JSON.stringify(entity, null, 2)
     const lines = output.split('\n')
     for (const line of lines) {
-      this.log(line)
+      // Bypass the shim to avoid misleading debug messages.
+      super.log(line)
     }
   }
 
-  // Default implementation of logTable uses cli_ux.  That module must be lazy-loaded so that loading it at module scope
-  // doesn't break the workbench (this function will not be called in the workbench since a CaptureLogger will always be used).
+  // Implement logTable for logger interface.  This context assumes textual output, but it matters whether the
+  // user requested JSON or not.  If useJSON is true, we just use the logJSON logic on the array value.  If
+  // it is false, we use cli_ux to format and display the table.  That module must be lazy-loaded so that loading
+  // it at module scope doesn't break the workbench (this function will not be called in the workbench since a
+  // CaptureLogger will always be used).
   logTable(data: Record<string, unknown>[], columns: Record<string, unknown>, options: Record<string, unknown> = {}): void {
-    debugJSON('Table logging invoked')
+    if (this.useJSON) {
+      this.logJSON(data)
+      return
+    }
     if (!cli) {
       cli = require('cli-ux').cli
     }
     cli.table(data, columns, options)
   }
 
+  // Add a shim around Command.log to debug usage of the --json flag
+  log(message = '', ...args: any[]): void {
+    if (this.useJSON) {
+      debugJSON('Normal log method called with --json in effect')
+    }
+    super.log(message, ...args)
+  }
+
+  // The logOutput command either logs JSON or normal output depending on the flag.
+  // Its use by commands is optional.
+  logOutput(entity: any, msgs: string[]): void {
+    if (this.useJSON) {
+      this.logJSON(entity)
+      return
+    }
+    for (const msg of msgs) {
+      this.log(msg)
+    }
+  }
+
   // Generic oclif run() implementation.   Parses and then invokes the abstract runCommand method
   async run(): Promise<void> {
     const { argv, args, flags } = this.parse(this.constructor as typeof NimBaseCommand)
     debug('run with rawArgv: %O, argv: %O, args: %O, flags: %O', this.argv, argv, args, flags)
+    // Not clear that we should have to do the following but apparently we do.  It might be
+    // a consequence of the token-ungluing/regluing that we do in main.ts.  TODO investigate.
     const bad = argv.find(arg => arg.startsWith('-'))
     if (bad) { this.handleError(`Unrecognized flag: ${bad}`) }
     // Allow for a logger to be passed in when invoked programmatically.  This only has effect on aio commands if the logger is a CaptureLogger
@@ -203,6 +243,8 @@ export abstract class NimBaseCommand extends Command implements NimLogger {
     }
     const options = (this.config as ExtIConfig).options
     const logger = options ? options.logger : undefined
+    // Set global json flag for correct handling of tables and optional debugging of command conformance.
+    this.useJSON = flags.json
     await this.runCommand(this.argv, argv, args, flags, logger || this)
   }
 
@@ -242,9 +284,7 @@ export abstract class NimBaseCommand extends Command implements NimLogger {
   // Generic kui runner.  Unlike run(), this gets partly pre-parsed input and doesn't do a full oclif parse.
   // It also uses the CaptureLogger so it can return the output in the forms appropriate for kui display
   // (worst case, just an array of text lines).  In addition to kui's 'argv' and 'parsedOptions' values,
-  // it gets a 'skip' value (the number of arguments consumed by the command itself), and the static
-  // args member of the concrete subclass of this class that is being dispatched to.   That could probably
-  // be computed here but would require more introspective code; easier for the caller to do it.
+  // it gets a 'skip' value (the number of arguments consumed by the command itself).
   async dispatch(argv: string[], skip: number, argTemplates: IArg<string>[], parsedOptions: any): Promise<CaptureLogger> {
     // Duplicate oclif's args parsing conventions.  Some parsing has already been done by kui
     debug('dispatch with argv: %O, skip: %d, argTemplates: %O, parsedOptions: %O', argv, skip, argTemplates, parsedOptions)

--- a/src/commands/auth/current.ts
+++ b/src/commands/auth/current.ts
@@ -71,10 +71,10 @@ export default class AuthInspect extends NimBaseCommand {
     if (production) {
       ans.production = creds.production
     }
-    if (Object.keys(ans).length === 1) {
+    if (Object.keys(ans).length === 1 && !flags.json) {
       logger.log(String(Object.values(ans)[0]))
     } else {
-      // The 'json' flag is not consulted because JSON output is assumed
+      // In addition to respecting --json, this command does JSON output anyway if there is more than one element
       logger.logJSON(ans)
     }
   }

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -28,7 +28,7 @@ export default class AuthLogin extends NimBaseCommand {
     ...NimBaseCommand.flags
   }
 
-  static args = [{ name: 'token', description: 'String provided by Nimbella Corp', required: false }]
+  static args = [{ name: 'token', description: 'A string provided to you for login purposes', required: false }]
 
   static aliases = ['login']
 
@@ -76,14 +76,20 @@ export default class AuthLogin extends NimBaseCommand {
           // In the CLI, a true response indicates a "long" provisioning (the wait for the redirect timed out).
           // It can also happen if the user just ignores the browser and does nothing.
           // We also reassure the user, but with some more instructions.
-          logger.log('If you logged in, your account is being provisioned and should be ready in a minute or two.')
-          logger.log("Try another 'nim auth login' then.")
+          const msgs = [
+            'If you logged in, your account is being provisioned and should be ready in a minute or two.',
+            'Try another \'nim auth login\' then.'
+          ]
+          logger.logOutput({ status: 'ShouldRetry' }, msgs)
         }
         return
       } else {
         logger.handleError(`Login failed.  Response was '${response}'`)
       }
     }
-    logger.log(`Stored a credential set for namespace '${credentials.namespace}' on host '${credentials.ow.apihost}'`)
+    const msgs = [
+      `Stored a credential set for namespace '${credentials.namespace}' on host '${credentials.ow.apihost}'`
+    ]
+    logger.logOutput({ status: 'Ok', namespace: credentials.namespace, apihost: credentials.ow.apihost }, msgs)
   }
 }

--- a/src/commands/auth/refresh.ts
+++ b/src/commands/auth/refresh.ts
@@ -43,10 +43,18 @@ export default class AuthRefresh extends NimBaseCommand {
 
     const creds = await (namespace ? getCredentialsForNamespace(namespace, host, authPersister)
       : getCredentials(authPersister)).catch(err => logger.handleError('', err))
-    logger.log('Contacting the backend')
+    if (!flags.json) {
+      logger.log('Contacting the backend')
+    }
     const token = await getCredentialsToken(creds.ow, logger)
-    logger.log('Refreshing credentials')
+    if (!flags.json) {
+      logger.log('Refreshing credentials')
+    }
     await doLogin(token, authPersister, creds.ow.apihost)
-    logger.log(`New credentials stored for namespace '${creds.namespace}'`)
+    if (flags.json) {
+      logger.logJSON({ status: 'Ok', namespace: creds.namespace })
+    } else {
+      logger.log(`New credentials stored for namespace '${creds.namespace}'`)
+    }
   }
 }

--- a/src/commands/auth/switch.ts
+++ b/src/commands/auth/switch.ts
@@ -30,6 +30,7 @@ export default class AuthSwitch extends NimBaseCommand {
     const host = parseAPIHost(flags.apihost)
     const [namespace, _host] = (await disambiguateNamespace(args.namespace, host, choicePrompter).catch(err => logger.handleError('', err))).split(' on ')
     const creds = await switchNamespace(namespace, _host, authPersister).catch(err => logger.handleError('', err))
-    logger.log(`Successful switch to namespace '${namespace}' on API host '${creds.ow.apihost}'`)
+    logger.logOutput({ status: 'Ok', namespace, apihost: creds.ow.apihost },
+      [`Successful switch to namespace '${namespace}' on API host '${creds.ow.apihost}'`])
   }
 }

--- a/src/commands/project/get-metadata.ts
+++ b/src/commands/project/get-metadata.ts
@@ -51,7 +51,8 @@ export class ProjectMetadata extends NimBaseCommand {
       include,
       exclude,
       remoteBuild: false,
-      webLocal: undefined
+      webLocal: undefined,
+      json: true // output will always be JSON
     }
     this.debug('cmdFlags', cmdFlags)
     // Convert include/exclude flags into an Includer object
@@ -76,7 +77,7 @@ export class ProjectMetadata extends NimBaseCommand {
     }
 
     // Display result
-    logger.logJSON(result as Record<string, unknown>)
+    logger.logJSON(result)
   }
 }
 

--- a/src/commands/project/watch.ts
+++ b/src/commands/project/watch.ts
@@ -56,7 +56,7 @@ export default class ProjectWatch extends NimBaseCommand {
     if (isGithub && !flags['anon-github']) {
       logger.handleError('you don\'t have github authorization.  Use \'nim auth github --initial\' to activate it.')
     }
-    const { target, env, apihost, auth, insecure, yarn, include, exclude } = flags
+    const { target, env, apihost, auth, insecure, yarn, include, exclude, json } = flags
     const cmdFlags: Flags = {
       verboseBuild: flags['verbose-build'],
       verboseZip: flags.verboseZip,
@@ -68,7 +68,8 @@ export default class ProjectWatch extends NimBaseCommand {
       webLocal: flags['web-local'],
       include,
       exclude,
-      remoteBuild: flags['remote-build']
+      remoteBuild: flags['remote-build'],
+      json
     }
     this.debug('cmdFlags', cmdFlags)
     const { creds, owOptions } = await processCredentials(insecure, apihost, auth, target, logger)

--- a/src/generator/project.ts
+++ b/src/generator/project.ts
@@ -75,11 +75,14 @@ export async function createOrUpdateProject(updating: boolean, args: any, flags:
   }
 
   if (updating) {
-    logger.log(`The project '${args.project}' was updated.`)
-  } else { // create or flags.overwrite
-    logger.log(`A sample project called '${args.project}' was created for you.`)
-    logger.log('You may deploy it by running the command shown on the next line:')
-    logger.log(`  nim project deploy ${args.project}`)
+    logger.logOutput({ status: 'Updated', project: args.project }, [`The project '${args.project}' was updated.`])
+  } else {
+    const msgs = [
+      `A sample project called '${args.project}' was created for you.`,
+      'You may deploy it by running the command shown on the next line:',
+      `  nim project deploy ${args.project}`
+    ]
+    logger.logOutput({ status: 'Created', project: args.project }, msgs)
   }
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "module": "commonjs",
     "outDir": "lib",
     "rootDir": "src",
-    "target": "es2017"
+    "target": "es2019"
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
With this PR, the new `--json` flag is respected by all `nim auth ...` commands and many `nim project ...` commands.   The `project watch` and `project serve-web` commands, which, by design produce continuous output in a separate console window, are not changed for now.