### PR TITLE
Introduce "branding" abstraction for altering output details

### DIFF
--- a/src/NimBaseCommand.ts
+++ b/src/NimBaseCommand.ts
@@ -48,10 +48,14 @@ export interface Branding {
   cmdName: string
   // The default API host suffix
   defaultHostSuffix: string
-  // Do full API Host names start with 'api' by convention?
-  hostsStartWithApi: boolean
+  // Typical prefix on most API host names
+  hostPrefix: string
   // Instructions to user to recover when there is no current namespace
   namespaceRepair: string
+  // Production workbench URL (may be blank)
+  workbenchURL: string
+  // Preview workbench URL
+  previewWorkbenchURL: string
 }
 
 // Branding.  The values here reflect the standard 'nim from Nimbella' branding.
@@ -59,8 +63,10 @@ export let branding: Branding = {
   brand: 'Nimbella',
   cmdName: 'nim',
   defaultHostSuffix: '.nimbella.io',
-  hostsStartWithApi: true,
-  namespaceRepair: "Use 'nim logon' to create a new one or 'nim auth switch' to use an existing one"
+  hostPrefix: 'api',
+  namespaceRepair: "Use 'nim logon' to create a new one or 'nim auth switch' to use an existing one",
+  workbenchURL: 'https://apigcp.nimbella.io/wb',
+  previewWorkbenchURL: 'https://preview-apigcp.nimbella.io/workbench'
 }
 
 // A place where workbench can store its help helper
@@ -476,8 +482,8 @@ export function parseAPIHost(host: string | undefined): string | undefined {
   if (host.includes('.')) {
     return 'https://' + host
   }
-  if (branding.hostsStartWithApi && !host.startsWith('api')) {
-    host = 'api' + host
+  if (branding.hostPrefix && !host.startsWith(branding.hostPrefix)) {
+    host = branding.hostPrefix + host
   }
   return 'https://' + host + branding.defaultHostSuffix
 }

--- a/src/NimBaseCommand.ts
+++ b/src/NimBaseCommand.ts
@@ -40,6 +40,29 @@ const debug = createDebug('nim:base')
 const verboseError = createDebug('nim:error')
 const debugJSON = createDebug('nim:json')
 
+// Schema that the 'branding' structure is expected to follow
+export interface Branding {
+  // The major brand
+  brand: string
+  // The command name
+  cmdName: string
+  // The default API host suffix
+  defaultHostSuffix: string
+  // Do full API Host names start with 'api' by convention?
+  hostsStartWithApi: boolean
+  // Instructions to user to recover when there is no current namespace
+  namespaceRepair: string
+}
+
+// Branding.  The values here reflect the standard 'nim from Nimbella' branding.
+export let branding: Branding = {
+  brand: 'Nimbella',
+  cmdName: 'nim',
+  defaultHostSuffix: '.nimbella.io',
+  hostsStartWithApi: true,
+  namespaceRepair: "Use 'nim logon' to create a new one or 'nim auth switch' to use an existing one"
+}
+
 // A place where workbench can store its help helper
 let helpHelper: (usage: Record<string, any>) => never
 
@@ -49,6 +72,11 @@ let cli: any
 // Called from workbench init
 export function setHelpHelper(helper: (usage: Record<string, any>) => never): void {
   helpHelper = helper
+}
+
+// May be called from main or from a library interface to set branding
+export function setBranding(newValue: Branding): void {
+  branding = newValue
 }
 
 // Common behavior expected by runCommand implementations ... abstracts some features of
@@ -382,7 +410,7 @@ function improveErrorMsg(msg: string, err?: any): string {
       }
     } else if (err instanceof GaxiosError) {
       pretty = `An error occurred communicating with Cloud Storage.
-This may be a problem with your Nimbella credentials.
+This may be a problem with your ${branding.brand} credentials.
 Repeat the command with the '--verbose' flag for more detail`
     } // add more case logic here
   }
@@ -448,10 +476,10 @@ export function parseAPIHost(host: string | undefined): string | undefined {
   if (host.includes('.')) {
     return 'https://' + host
   }
-  if (!host.startsWith('api')) {
+  if (branding.hostsStartWithApi && !host.startsWith('api')) {
     host = 'api' + host
   }
-  return 'https://' + host + '.nimbella.io'
+  return 'https://' + host + branding.defaultHostSuffix
 }
 
 // Stuff API host and AUTH key into the environment so that AIO does not look for these in .wskprops when invoked by nim.
@@ -480,7 +508,7 @@ function fixAioCredentials(logger: NimLogger, flags: any) {
       debug(`Error retrieving credentials for '${currentNamespace}' on host '${currentHost}'`)
     }
   } else {
-    logger.handleError("You do not have a current namespace.  Use 'nim auth login' to create a new one or 'nim auth switch' to use an existing one")
+    logger.handleError(`You do not have a current namespace.  ${branding.namespaceRepair}`)
   }
   process.env.AIO_RUNTIME_APIHOST = currentHost
   process.env.AIO_RUNTIME_AUTH = currentAuth

--- a/src/commands/auth/export.ts
+++ b/src/commands/auth/export.ts
@@ -12,7 +12,7 @@
  */
 
 import { getCredentials, getCredentialsForNamespace, authPersister } from '@nimbella/nimbella-deployer'
-import { NimBaseCommand, NimLogger, disambiguateNamespace, parseAPIHost } from '../../NimBaseCommand'
+import { NimBaseCommand, NimLogger, disambiguateNamespace, parseAPIHost, branding } from '../../NimBaseCommand'
 import { flags } from '@oclif/command'
 
 import { getCredentialsToken } from '../../oauth'
@@ -46,9 +46,9 @@ export default class AuthExport extends NimBaseCommand {
     } else {
       logger.log(`The following token encodes credentials for namespace '${creds.namespace}' on host '${creds.ow.apihost}'`)
       if (nonExpiring) {
-        logger.log('It may be used with `nim auth login` and does not expire.')
+        logger.log(`It may be used with '${branding.cmdName} auth login' and does not expire.`)
       } else {
-        logger.log('It may be used with `nim auth login` within the next five minutes.')
+        logger.log(`It may be used with '${branding.cmdName} auth login' within the next five minutes.`)
       }
       logger.log(token)
     }

--- a/src/commands/auth/list.ts
+++ b/src/commands/auth/list.ts
@@ -13,7 +13,7 @@
 
 import { flags } from '@oclif/command'
 import { getCredentialDict, authPersister, CredentialRow } from '@nimbella/nimbella-deployer'
-import { NimBaseCommand, NimLogger, parseAPIHost } from '../../NimBaseCommand'
+import { NimBaseCommand, NimLogger, parseAPIHost, branding } from '../../NimBaseCommand'
 
 import { bold } from 'chalk'
 
@@ -25,7 +25,7 @@ const NO = '    no  '
 const MAYBE = '   -?-  '
 
 export default class AuthList extends NimBaseCommand {
-  static description = 'List all your Nimbella namespaces'
+  static description = `List all your ${branding.brand} namespaces`
 
   static flags = {
     apihost: flags.string({ description: 'Only list namespaces for the specified API host' }),

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -13,10 +13,10 @@
 
 import { flags } from '@oclif/command'
 import { doLogin, doAdminLogin, addCredentialAndSave, Credentials, authPersister } from '@nimbella/nimbella-deployer'
-import { NimBaseCommand, NimLogger, parseAPIHost } from '../../NimBaseCommand'
+import { NimBaseCommand, NimLogger, parseAPIHost, branding } from '../../NimBaseCommand'
 
 export default class AuthLogin extends NimBaseCommand {
-  static description = 'Gain access to a Nimbella namespace'
+  static description = `Gain access to a ${branding.brand} namespace`
 
   static flags = {
     apihost: flags.string({ description: 'API host to use for authentication' }),

--- a/src/commands/auth/logout.ts
+++ b/src/commands/auth/logout.ts
@@ -14,12 +14,12 @@
 import { flags } from '@oclif/command'
 import { getCredentials, forgetNamespace, getCredentialList, authPersister, getApiHosts }
   from '@nimbella/nimbella-deployer'
-import { NimBaseCommand, NimLogger, parseAPIHost, NimFeedback, disambiguateNamespace, CaptureLogger }
+import { NimBaseCommand, NimLogger, parseAPIHost, NimFeedback, disambiguateNamespace, CaptureLogger, branding }
   from '../../NimBaseCommand'
 import { prompt, choicePrompter } from '../../ui'
 
 export default class AuthLogout extends NimBaseCommand {
-  static description = 'Drop access to Nimbella namespaces'
+  static description = `Drop access to ${branding.brand} namespaces`
 
   static flags = {
     apihost: flags.string({ description: 'API host serving the namespace(s)' }),

--- a/src/commands/auth/refresh.ts
+++ b/src/commands/auth/refresh.ts
@@ -14,13 +14,13 @@
 import {
   doLogin, getCredentials, getCredentialsForNamespace, authPersister
 } from '@nimbella/nimbella-deployer'
-import { NimBaseCommand, NimLogger, parseAPIHost, disambiguateNamespace } from '../../NimBaseCommand'
+import { NimBaseCommand, NimLogger, parseAPIHost, disambiguateNamespace, branding } from '../../NimBaseCommand'
 import { flags } from '@oclif/command'
 import { getCredentialsToken } from '../../oauth'
 import { choicePrompter } from '../../ui'
 
 export default class AuthRefresh extends NimBaseCommand {
-    static description = 'Refresh Nimbella namespace credentials by re-reading the latest from the backend'
+    static description = `Refresh ${branding.brand} namespace credentials by re-reading the latest from the backend`
 
   static flags = {
     apihost: flags.string({ description: 'API host serving the namespace' }),

--- a/src/commands/auth/switch.ts
+++ b/src/commands/auth/switch.ts
@@ -13,11 +13,11 @@
 
 import { flags } from '@oclif/command'
 import { switchNamespace, authPersister } from '@nimbella/nimbella-deployer'
-import { NimBaseCommand, NimLogger, parseAPIHost, disambiguateNamespace } from '../../NimBaseCommand'
+import { NimBaseCommand, NimLogger, parseAPIHost, disambiguateNamespace, branding } from '../../NimBaseCommand'
 import { choicePrompter } from '../../ui'
 
 export default class AuthSwitch extends NimBaseCommand {
-  static description = 'Switch to a different Nimbella namespace'
+  static description = `Switch to a different ${branding.brand} namespace`
 
   static flags = {
     apihost: flags.string({ description: 'API host serving the target namespace' }),

--- a/src/commands/doc.ts
+++ b/src/commands/doc.ts
@@ -12,7 +12,7 @@
  */
 
 import { inBrowser } from '@nimbella/nimbella-deployer'
-import { NimBaseCommand, NimLogger } from '../NimBaseCommand'
+import { NimBaseCommand, NimLogger, branding } from '../NimBaseCommand'
 
 import { open } from '../ui'
 const PUBLIC_DOC = 'https://docs.nimbella.com'
@@ -28,8 +28,8 @@ export default class Doc extends NimBaseCommand {
 
   async runCommand(rawArgv: string[], argv: string[], args: any, flags: any, logger: NimLogger): Promise<void> {
     if (inBrowser) {
-      logger.log('This displays the Nimbella CLI documentation')
-      logger.log('Much of the Nimbella CLI command set also works in the workbench')
+      logger.log(`This displays the ${branding.brand} CLI documentation`)
+      logger.log(`Much of the ${branding.brand} CLI command set also works in the workbench`)
       logger.log('Type "menu" for some more orientation to the workbench')
     }
     await open(PUBLIC_DOC)

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -13,17 +13,17 @@
 
 import { flags } from '@oclif/command'
 import { wskRequest, inBrowser, authPersister, getCredentials, initRuntimes } from '@nimbella/nimbella-deployer'
-import { NimBaseCommand, NimLogger, parseAPIHost } from '../NimBaseCommand'
+import { NimBaseCommand, NimLogger, parseAPIHost, branding } from '../NimBaseCommand'
 import { open } from '../ui'
 
 export default class Info extends NimBaseCommand {
-  static description = "Show information about this version of 'nim'"
+  static description = `Show information about this version of '${branding.cmdName}'`
 
   static flags = {
     license: flags.boolean({ description: 'Display the license', hidden: inBrowser }),
     changes: flags.boolean({ description: 'Display the change history', hidden: inBrowser }),
     runtimes: flags.boolean({ description: 'List the supported runtimes' }),
-    limits: flags.boolean({ description: 'List the applicable Nimbella system limits' }),
+    limits: flags.boolean({ description: `List the applicable ${branding.brand} system limits` }),
     apihost: flags.string({ description: 'API host to query for runtimes and limits (ignored otherwise)', hidden: true }),
     ...NimBaseCommand.flags
   }
@@ -60,14 +60,14 @@ export default class Info extends NimBaseCommand {
       }
       const cli = pj?.version?.includes('-') ? pj : (vj || pj)
       const aio = require('@adobe/aio-cli-plugin-runtime/package.json')
-      logger.log(`Nimbella CLI version: ${cli.version}`)
+      logger.log(`${branding.brand} CLI version: ${cli.version}`)
       logger.log(`Adobe I/O version:    ${aio.version}`)
       if (!inBrowser) {
-        logger.log("'nim info --license' to display the license")
-        logger.log("'nim info --changes' to display the change history")
+        logger.log(`'${branding.cmdName} info --license' to display the license`)
+        logger.log(`'${branding.cmdName} info --changes' to display the change history`)
       }
-      logger.log("'nim info --runtimes' to display the supported runtimes")
-      logger.log("'nim info --limits' to display the limits")
+      logger.log(`'${branding.cmdName} info --runtimes' to display the supported runtimes`)
+      logger.log(`'${branding.cmdName} info --limits' to display the limits`)
     }
   }
 

--- a/src/commands/object/create.ts
+++ b/src/commands/object/create.ts
@@ -16,7 +16,7 @@ import { basename, isAbsolute, join } from 'path'
 import { existsSync, lstatSync } from 'fs'
 import { spinner } from '../../ui'
 import { StorageClient, authPersister } from '@nimbella/nimbella-deployer'
-import { NimBaseCommand, NimLogger } from '../../NimBaseCommand'
+import { NimBaseCommand, NimLogger, branding } from '../../NimBaseCommand'
 import { getObjectStorageClient } from '../../storage/clients'
 
 export default class ObjectCreate extends NimBaseCommand {
@@ -61,7 +61,7 @@ export default class ObjectCreate extends NimBaseCommand {
 
       const exists = await client.file(targetPath).exists()
       if (exists) {
-        logger.handleError(`${targetPath} already exists, use 'object:update' to update it. e.g. nim object update ${objectName}`)
+        logger.handleError(`${targetPath} already exists, use 'object:update' to update it. e.g. ${branding.cmdName} object update ${objectName}`)
       }
 
       loader.start(`adding ${objectName}`, 'uploading', { stdout: true })

--- a/src/commands/object/update.ts
+++ b/src/commands/object/update.ts
@@ -16,7 +16,7 @@ import { basename, isAbsolute } from 'path'
 import { existsSync, lstatSync } from 'fs'
 import { spinner } from '../../ui'
 import { StorageClient, authPersister } from '@nimbella/nimbella-deployer'
-import { NimBaseCommand, NimLogger } from '../../NimBaseCommand'
+import { NimBaseCommand, NimLogger, branding } from '../../NimBaseCommand'
 import { getObjectStorageClient } from '../../storage/clients'
 
 export default class ObjectUpdate extends NimBaseCommand {
@@ -57,7 +57,7 @@ export default class ObjectUpdate extends NimBaseCommand {
 
       const exists = await client.file(targetPath).exists()
       if (!exists) {
-        logger.handleError(`${targetPath} doesn't exist, use 'object:add' to add it. e.g. nim object add ${objectName}`)
+        logger.handleError(`${targetPath} doesn't exist, use 'object:add' to add it. e.g. ${branding.cmdName} object add ${objectName}`)
       }
 
       loader.start(`updating ${targetPath}`, 'uploading', { stdout: true })

--- a/src/commands/project/create.ts
+++ b/src/commands/project/create.ts
@@ -13,12 +13,12 @@
 
 import { flags } from '@oclif/command'
 import { inBrowser } from '@nimbella/nimbella-deployer'
-import { NimBaseCommand, NimLogger } from '../../NimBaseCommand'
+import { NimBaseCommand, NimLogger, branding } from '../../NimBaseCommand'
 import { createOrUpdateProject, languages } from '../../generator/project'
 
 export default class ProjectCreate extends NimBaseCommand {
   static strict = false
-  static description = 'Create a Nimbella Project'
+  static description = `Create a ${branding.brand} Project`
   static plugins = { postman: 'ppm', openapi: 'poa', sample: 'sample' }
 
   static flags = {
@@ -58,7 +58,7 @@ export default class ProjectCreate extends NimBaseCommand {
       this.doHelp()
     }
     if (inBrowser) {
-      logger.handleError('\'project create\' needs local file access. Use the \'nim\' CLI on your local machine')
+      logger.handleError(`'project create' needs local file access. Use the '${branding.cmdName}' CLI on your local machine`)
     }
     if (flags.type && flags.type === 'sample') {
       args.project = args.project || flags.type
@@ -68,7 +68,7 @@ export default class ProjectCreate extends NimBaseCommand {
       if (command) {
         await command.load().run(rawArgv)
       } else {
-        logger.handleError(`the ${flags.type} plugin is not installed. try 'nim plugins add ${flags.type}'`)
+        logger.handleError(`the ${flags.type} plugin is not installed. try '${branding.cmdName} plugins add ${flags.type}'`)
       }
     } else {
       await createOrUpdateProject(false, args, flags, logger)

--- a/src/commands/project/deploy.ts
+++ b/src/commands/project/deploy.ts
@@ -18,12 +18,13 @@ import {
 } from '@nimbella/nimbella-deployer'
 
 import {
-  NimBaseCommand, NimLogger, NimFeedback, parseAPIHost, disambiguateNamespace, CaptureLogger, replaceErrors
+  NimBaseCommand, NimLogger, NimFeedback, parseAPIHost, disambiguateNamespace, CaptureLogger,
+  replaceErrors, branding
 } from '../../NimBaseCommand'
 import * as path from 'path'
 import { choicePrompter } from '../../ui'
 export class ProjectDeploy extends NimBaseCommand {
-  static description = 'Deploy Nimbella projects'
+  static description = `Deploy ${branding.brand} projects`
 
   static flags = {
     target: flags.string({ description: 'The target namespace' }),
@@ -64,7 +65,7 @@ export class ProjectDeploy extends NimBaseCommand {
       logger.handleError('only GitHub projects are deployable from the cloud')
     }
     if (isGithub && !flags['anon-github'] && !getGithubAuth(authPersister)) {
-      logger.handleError('you don\'t have GitHub authorization.  Use \'nim auth github\' to activate it.')
+      logger.handleError(`you don't have GitHub authorization.  Use '${branding.cmdName} auth github' to activate it.`)
     }
     if (multiple && json) {
       logger.handleError('the --json flag may not be used when deploying multiple projects')
@@ -254,7 +255,7 @@ function displayResult(result: DeployResponse, watching: boolean, webLocal: stri
       logger.log(`Skipped ${skippedWeb} unchanged web resources${bucketClause}`)
     }
     if (actions.length > 0) {
-      logger.log('Deployed actions (\'nim action get <actionName> --url\' for URL):')
+      logger.log(`Deployed actions ('${branding.brand} action get <actionName> --url' for URL):`)
       for (const action of actions) {
         logger.log(`  - ${action}`)
       }

--- a/src/commands/project/get-metadata.ts
+++ b/src/commands/project/get-metadata.ts
@@ -17,9 +17,9 @@ import {
   getRuntimeForAction
 } from '@nimbella/nimbella-deployer'
 
-import { NimBaseCommand, NimLogger } from '../../NimBaseCommand'
+import { NimBaseCommand, NimLogger, branding } from '../../NimBaseCommand'
 export class ProjectMetadata extends NimBaseCommand {
-  static description = 'Obtain metadata of a Nimbella project'
+  static description = `Obtain metadata of a ${branding.brand} project`
 
   static flags = {
     env: flags.string({ description: 'Path to environment file' }),
@@ -38,7 +38,7 @@ export class ProjectMetadata extends NimBaseCommand {
       logger.handleError('only GitHub projects are accessible from the cloud')
     }
     if (isGithub && !flags['anon-github'] && !getGithubAuth(authPersister)) {
-      logger.handleError('you don\'t have GitHub authorization.  Use \'nim auth github\' to activate it.')
+      logger.handleError(`you don't have GitHub authorization.  Use '${branding.cmdName} auth github' to activate it.`)
     }
     const cmdFlags: Flags = {
       verboseBuild: false,

--- a/src/commands/project/update.ts
+++ b/src/commands/project/update.ts
@@ -12,14 +12,14 @@
  */
 
 import { inBrowser } from '@nimbella/nimbella-deployer'
-import { NimBaseCommand, NimLogger } from '../../NimBaseCommand'
+import { NimBaseCommand, NimLogger, branding } from '../../NimBaseCommand'
 import { createOrUpdateProject, seemsToBeProject } from '../../generator/project'
 import ProjectCreate from './create'
 import { flags } from '@oclif/command'
 
 const plugins = { postman: 'ppm', openapi: 'poa', sample: 'sample', apispecgen: 'pas' }
 export default class ProjectUpdate extends NimBaseCommand {
-  static description = 'Update a Nimbella Project'
+  static description = `Update a ${branding.brand} Project`
   static strict = false
   static flags = Object.assign(
     ProjectCreate.flags,
@@ -49,7 +49,7 @@ export default class ProjectUpdate extends NimBaseCommand {
       this.doHelp()
     }
     if (inBrowser) {
-      logger.handleError('\'project update\' needs local file access. Use the \'nim\' CLI on your local machine')
+      logger.handleError(`'project update' needs local file access. Use the '${branding.cmdName}' CLI on your local machine`)
     }
     if (!seemsToBeProject(args.project)) {
       logger.handleError(`${args.project} doesn't appear to be a project`)
@@ -61,7 +61,7 @@ export default class ProjectUpdate extends NimBaseCommand {
       if (command) {
         await command.load().run(rawArgv)
       } else {
-        logger.handleError(`the ${configCommand} plugin is not installed. try 'nim plugins add ${configCommand}'`)
+        logger.handleError(`the ${configCommand} plugin is not installed. try '${branding.cmdName} plugins add ${configCommand}'`)
       }
       return
     }
@@ -71,7 +71,7 @@ export default class ProjectUpdate extends NimBaseCommand {
       if (command) {
         await command.load().run(rawArgv)
       } else {
-        logger.handleError(`the ${flags.type} plugin is not installed. try 'nim plugins add ${flags.type}'`)
+        logger.handleError(`the ${flags.type} plugin is not installed. try '${branding.cmdName} plugins add ${flags.type}'`)
       }
     } else {
       await createOrUpdateProject(true, args, flags, logger)

--- a/src/commands/project/watch.ts
+++ b/src/commands/project/watch.ts
@@ -12,7 +12,7 @@
  */
 
 import { Flags, Credentials, OWOptions, inBrowser, isGithubRef, delay, isExcluded } from '@nimbella/nimbella-deployer'
-import { NimBaseCommand, NimLogger } from '../../NimBaseCommand'
+import { NimBaseCommand, NimLogger, branding } from '../../NimBaseCommand'
 import { ProjectDeploy, processCredentials, doDeploy } from './deploy'
 
 import * as fs from 'fs'
@@ -20,7 +20,7 @@ import * as chokidar from 'chokidar'
 import * as path from 'path'
 
 export default class ProjectWatch extends NimBaseCommand {
-  static description = 'Watch Nimbella projects, deploying incrementally on change'
+  static description = `Watch ${branding.brand} projects, deploying incrementally on change`
 
   static flags: any = {
     target: ProjectDeploy.flags.target,
@@ -54,7 +54,7 @@ export default class ProjectWatch extends NimBaseCommand {
     // Otherwise ...
     const isGithub = argv.some(project => isGithubRef(project))
     if (isGithub && !flags['anon-github']) {
-      logger.handleError('you don\'t have github authorization.  Use \'nim auth github\' to activate it.')
+      logger.handleError(`you don't have github authorization.  Use '${branding.cmdName} auth github' to activate it.`)
     }
     const { target, env, apihost, auth, insecure, yarn, include, exclude, json } = flags
     const cmdFlags: Flags = {

--- a/src/commands/web/create.ts
+++ b/src/commands/web/create.ts
@@ -16,7 +16,7 @@ import { basename, isAbsolute, join } from 'path'
 import { existsSync, lstatSync } from 'fs'
 import { spinner } from '../../ui'
 import { StorageClient, authPersister } from '@nimbella/nimbella-deployer'
-import { NimBaseCommand, NimLogger } from '../../NimBaseCommand'
+import { NimBaseCommand, NimLogger, branding } from '../../NimBaseCommand'
 
 import { getWebStorageClient } from '../../storage/clients'
 
@@ -63,7 +63,7 @@ export default class WebContentCreate extends NimBaseCommand {
 
       const exists = await client.file(targetPath).exists()
       if (exists) {
-        logger.handleError(`${targetPath} already exists, use 'web:update' to update it. e.g. nim web update ${contentName}`)
+        logger.handleError(`${targetPath} already exists, use 'web:update' to update it. e.g. ${branding.cmdName} web update ${contentName}`)
       }
 
       loader.start(`adding ${contentName}`, 'uploading', { stdout: true })

--- a/src/commands/web/update.ts
+++ b/src/commands/web/update.ts
@@ -16,7 +16,7 @@ import { basename, isAbsolute } from 'path'
 import { existsSync, lstatSync } from 'fs'
 import { spinner } from '../../ui'
 import { StorageClient, authPersister } from '@nimbella/nimbella-deployer'
-import { NimBaseCommand, NimLogger } from '../../NimBaseCommand'
+import { NimBaseCommand, NimLogger, branding } from '../../NimBaseCommand'
 import { getWebStorageClient } from '../../storage/clients'
 
 export default class WebContentUpdate extends NimBaseCommand {
@@ -58,7 +58,7 @@ export default class WebContentUpdate extends NimBaseCommand {
 
       const exists = await client.file(targetPath).exists()
       if (!exists) {
-        logger.handleError(`${targetPath} doesn't exist, use 'web:create' to add it. e.g. nim web add ${contentName}`)
+        logger.handleError(`${targetPath} doesn't exist, use 'web:create' to add it. e.g. ${branding.cmdName} web add ${contentName}`)
       }
 
       loader.start(`updating ${targetPath}`, 'uploading', { stdout: true })

--- a/src/commands/workbench/login.ts
+++ b/src/commands/workbench/login.ts
@@ -13,14 +13,14 @@
 
 import * as WorkbenchRun from './run'
 import { authPersister, getCredentials } from '@nimbella/nimbella-deployer'
-import { NimBaseCommand, NimLogger } from '../../NimBaseCommand'
+import { NimBaseCommand, NimLogger, branding } from '../../NimBaseCommand'
 import { openWorkbench } from '../../workbench'
 
 import { getCredentialsToken } from '../../oauth'
 
 // Command to open the workbench from the CLI or switch between preview and production workbench for the purpose of transferring credentials
 export default class WorkbenchLogin extends NimBaseCommand {
-  static description = 'Open the Nimbella Workbench, logging in with current credentials'
+  static description = `Open the ${branding.brand} Workbench, logging in with current credentials`
 
   static flags: typeof WorkbenchRun.default.flags = WorkbenchRun.default.flags
 

--- a/src/commands/workbench/run.ts
+++ b/src/commands/workbench/run.ts
@@ -12,12 +12,12 @@
  */
 
 import { flags } from '@oclif/command'
-import { NimBaseCommand, NimLogger } from '../../NimBaseCommand'
+import { NimBaseCommand, NimLogger, branding } from '../../NimBaseCommand'
 import { openWorkbench } from '../../workbench'
 
 // Command to open the workbench from the CLI or switch between preview and production workbench for the purpose of running a command
 export default class WorkbenchRun extends NimBaseCommand {
-  static description = 'Open the Nimbella Workbench and run a command there'
+  static description = `Open the ${branding.brand} Workbench and run a command there`
 
   static flags = {
     ...NimBaseCommand.flags,

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ export async function runNimCommand(command: string, args: string[]): Promise<Ca
 
 export {
   NimBaseCommand, NimLogger, parseAPIHost, NimFeedback, disambiguateNamespace, CaptureLogger,
-  setBranding, setHelpHelper
+  Branding, setBranding, setHelpHelper
 } from './NimBaseCommand'
 // Remaining exports are just for workbench incorporation and are not supported API
 export { setKuiOpen, setKuiPrompter } from './ui'

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,9 @@ export async function runNimCommand(command: string, args: string[]): Promise<Ca
   return logger
 }
 
-export { NimBaseCommand, NimLogger, parseAPIHost, NimFeedback, disambiguateNamespace, CaptureLogger, setHelpHelper } from './NimBaseCommand'
+export {
+  NimBaseCommand, NimLogger, parseAPIHost, NimFeedback, disambiguateNamespace, CaptureLogger,
+  setBranding, setHelpHelper
+} from './NimBaseCommand'
 // Remaining exports are just for workbench incorporation and are not supported API
 export { setKuiOpen, setKuiPrompter } from './ui'

--- a/src/workbench.ts
+++ b/src/workbench.ts
@@ -11,20 +11,22 @@
  * governing permissions and limitations under the License.
  */
 
-import { NimLogger } from './NimBaseCommand'
+import { NimLogger, branding } from './NimBaseCommand'
 import { open } from './ui'
-const workbenchURL = 'https://apigcp.nimbella.io/wb'
-const previewURL = 'https://preview-apigcp.nimbella.io/workbench'
 
 // Utility to open the workbench with or without an initial command.
 // Used by both "workbench:run" and "workbench:login".
 // Not expected to be used in the browser.
 
-export function openWorkbench(command: string, preview: boolean, _logger: NimLogger): void {
+export function openWorkbench(command: string, preview: boolean, logger: NimLogger): void {
+  const url = preview ? branding.previewWorkbenchURL : branding.workbenchURL
+  if (!url) {
+    const wbName = preview ? 'A preview workbench' : 'The workbench'
+    logger.handleError(wbName + ' is not available for the current API host')
+  }
   let query = ''
   if (command) {
     query = '?command=' + encodeURIComponent(command)
   }
-  const url = (preview ? previewURL : workbenchURL) + query
-  open(url)
+  open(url + query)
 }


### PR DESCRIPTION
The brand name "Nimbella", references to the command name 'nim', and assumptions that the host is a subdomain of 'nimbella.io', were scattered throughout the code.   This change introduces a mutable `branding` structure in `NimBaseCommand` that is then consulted in all of these places.   The default behavior remains the same but an invoker using the library interfaces can now change this structure to "re-brand" the CLI.