### PR TITLE
(1) runNimCommandNoCapture added. (2) fix to 'project watch' when symlinks

### DIFF
--- a/src/NimBaseCommand.ts
+++ b/src/NimBaseCommand.ts
@@ -280,6 +280,7 @@ export abstract class NimBaseCommand extends Command implements NimLogger {
     // Set global json flag for correct handling of tables and optional debugging of command conformance.
     this.useJSON = flags.json
     await this.runCommand(this.argv, argv, args, flags, logger || this)
+    debug('runCommand returned')
   }
 
   // Helper used in the runCommand methods of aio shim classes.  Not used by Nimbella-sourced command classes.

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,15 @@ export async function runNimCommand(command: string, args: string[]): Promise<Ca
   return logger
 }
 
+// Variant on runNimCommand with no capture (output to stdout)
+export async function runNimCommandNoCapture(command: string, args: string[]): Promise<void> {
+  const cmd = require('./commands/' + command)
+  if (!cmd || !cmd.default) {
+    throw new Error(`'${command}' is not a 'nim' command`)
+  }
+  await cmd.default.run(args, { root: __dirname })
+}
+
 export {
   NimBaseCommand, NimLogger, parseAPIHost, NimFeedback, disambiguateNamespace, CaptureLogger,
   Branding, setBranding, setHelpHelper


### PR DESCRIPTION
This PR includes two fixes.

1.  A new library function `runNimCommandNoCapture` was added.   It is like `runNimCommand` but does not capture the output, which continues to go to `stdout`.   The intended use case is when invoking something like `project watch` or `project serve-web` that will run indefinitely in a separate window.
2. In using the above with `project watch` I discovered a bug in `project watch` (probably a bug in `chokidar`) .   If you are watching an area in which there might be  symlinks, the watcher can get fired repeatedly for a symlink that doesn't actually change.   It seems like symlinks always appear to be freshly added.  Since Nimbella projects do not depend on symlinks much and we actively discourage using them, I decided to fix this by ignoring symlink adds.   The symlinks are most likely to appear in a `node_modules` that has a `bin` folder (or in similar scenarios that arise in `python virtualenv` cases).   These are rarely created due to edits by humans.   They are more likely artifacts of an previous deployment.