### PR TITLE
Initiation message for remote build now includes the activation id

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1260,9 +1260,9 @@
       "dev": true
     },
     "@nimbella/nimbella-deployer": {
-      "version": "3.1.11",
-      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-3.1.11.tgz",
-      "integrity": "sha512-9bh/V7KOzTSqx4ak95Sr+R+vstmGtpV1+iJ1D4Lm9NGp0ThOzNq1HhMy+usVtBCToPr2NCDwykymuYsAP826Ow==",
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-3.1.12.tgz",
+      "integrity": "sha512-LPhFtALm95RZIrFsh9rdRcYNf5efn95OycC/5xbhpmVvUZsP8zXoZHQm5F0aqHaKVDI8/1c6kJbD3X/PkYlCdg==",
       "requires": {
         "@nimbella/sdk": "^1.3.5",
         "@nimbella/storage": "^0.0.7",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@adobe/aio-cli-plugin-runtime": "github:nimbella/aio-cli-plugin-runtime#v2021-11-19-1",
     "@adobe/aio-lib-core-config": "^2.0.0",
     "@adobe/aio-lib-runtime": "^2.0.0",
-    "@nimbella/nimbella-deployer": "^3.1.11",
+    "@nimbella/nimbella-deployer": "^3.1.12",
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "chalk": "^4.1.0",

--- a/tests/remote-build-go/test.bats
+++ b/tests/remote-build-go/test.bats
@@ -7,8 +7,8 @@ teardown_file() {
 @test "deploy go projects with remote build" {
   run $NIM project deploy $BATS_TEST_DIRNAME --remote-build
 	assert_success
-	assert_line "Submitted action 'default' for remote building and deployment in runtime go:default"
-	assert_line "Submitted action 'explicit' for remote building and deployment in runtime go:1.12"
+	assert_line -p "Submitted action 'default' for remote building and deployment in runtime go:default"
+	assert_line -p "Submitted action 'explicit' for remote building and deployment in runtime go:1.12"
 }
 
 @test "invoke remotely built go lang actions" {

--- a/tests/remote-build-java/test.bats
+++ b/tests/remote-build-java/test.bats
@@ -7,9 +7,9 @@ teardown_file() {
 @test "deploy java projects with remote build" {
   run $NIM project deploy $BATS_TEST_DIRNAME --remote-build
 	assert_success
-	assert_line "Submitted action 'default' for remote building and deployment in runtime java:default"
-	assert_line "Submitted action 'mvn' for remote building and deployment in runtime java:default"
-	assert_line "Submitted action 'gradle' for remote building and deployment in runtime java:default"
+	assert_line -p "Submitted action 'default' for remote building and deployment in runtime java:default"
+	assert_line -p "Submitted action 'mvn' for remote building and deployment in runtime java:default"
+	assert_line -p "Submitted action 'gradle' for remote building and deployment in runtime java:default"
 }
 
 @test "invoke remotely built java lang actions" {

--- a/tests/remote-build-php/test.bats
+++ b/tests/remote-build-php/test.bats
@@ -7,7 +7,7 @@ teardown_file() {
 @test "deploy php projects with remote build" {
   run $NIM project deploy $BATS_TEST_DIRNAME --remote-build
 	assert_success
-	assert_line "Submitted action 'default' for remote building and deployment in runtime php:default"
+	assert_line -p "Submitted action 'default' for remote building and deployment in runtime php:default"
 }
 
 @test "invoke remotely built php lang actions" {

--- a/tests/remote-build-python/test.bats
+++ b/tests/remote-build-python/test.bats
@@ -7,7 +7,7 @@ teardown_file() {
 @test "deploy python projects with remote build" {
   run $NIM project deploy $BATS_TEST_DIRNAME --remote-build
 	assert_success
-	assert_line "Submitted action 'default' for remote building and deployment in runtime python:default"
+	assert_line -p "Submitted action 'default' for remote building and deployment in runtime python:default"
 }
 
 @test "invoke remotely built python lang actions" {

--- a/tests/remote-build-swift/test.bats
+++ b/tests/remote-build-swift/test.bats
@@ -7,8 +7,8 @@ teardown_file() {
 @test "deploy swift projects with remote build" {
   run $NIM project deploy $BATS_TEST_DIRNAME --remote-build
 	assert_success
-	assert_line "Submitted action 'default' for remote building and deployment in runtime swift:default"
-	assert_line "Submitted action 'multi' for remote building and deployment in runtime swift:default"
+	assert_line -p "Submitted action 'default' for remote building and deployment in runtime swift:default"
+	assert_line -p "Submitted action 'multi' for remote building and deployment in runtime swift:default"
 }
 
 @test "invoke remotely built swift lang actions" {


### PR DESCRIPTION
Depending on the API host, the remote build initiation messages may add an activation id at the end.   This capability comes with deployer 3.1.12.  Remote build tests must adjust.