### PR TITLE
Upgrade to deployer 3.1.4, fixing several bugs.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -201,11 +201,11 @@
       }
     },
     "@aws-sdk/abort-controller": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.49.0.tgz",
-      "integrity": "sha512-1qLlgOgg3yrtm+AJEP7yoIk90o6ns3Dia8S9DRjj29jY40446etH3v/tIbHPE+em69HLXl1K6e5KD6t7EDxnlg==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.50.0.tgz",
+      "integrity": "sha512-QNr5uKO5mL5OyJr6w2yub3dF00WeLtw5qgNZIeb1bN2onbh3d8VreHi3glkXQw3SI1UE9O1HsqEknMJhTupvKg==",
       "requires": {
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/types": "3.50.0",
         "tslib": "^2.3.0"
       }
     },
@@ -227,55 +227,55 @@
       }
     },
     "@aws-sdk/client-s3": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.49.0.tgz",
-      "integrity": "sha512-LidddhZFxYb/jlEtHnbBpqVZmjgZNKY/jaZy3jRNcVhw8L0m1IYVigqgw5E6ta9/dma5EwLOA8Z21O/rCuDapw==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.50.0.tgz",
+      "integrity": "sha512-E0S7HHc0Daz2PdGZLvaG1sYtiOyx7DCWj9K4Y2EYIIozNljbSSFlDZs6dHC+0jArDFHJE2z7dVprv2hxxFClbg==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.49.0",
-        "@aws-sdk/config-resolver": "3.49.0",
-        "@aws-sdk/credential-provider-node": "3.49.0",
-        "@aws-sdk/eventstream-serde-browser": "3.49.0",
-        "@aws-sdk/eventstream-serde-config-resolver": "3.49.0",
-        "@aws-sdk/eventstream-serde-node": "3.49.0",
-        "@aws-sdk/fetch-http-handler": "3.49.0",
-        "@aws-sdk/hash-blob-browser": "3.49.0",
-        "@aws-sdk/hash-node": "3.49.0",
-        "@aws-sdk/hash-stream-node": "3.49.0",
-        "@aws-sdk/invalid-dependency": "3.49.0",
-        "@aws-sdk/md5-js": "3.49.0",
-        "@aws-sdk/middleware-apply-body-checksum": "3.49.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.49.0",
-        "@aws-sdk/middleware-content-length": "3.49.0",
-        "@aws-sdk/middleware-expect-continue": "3.49.0",
-        "@aws-sdk/middleware-host-header": "3.49.0",
-        "@aws-sdk/middleware-location-constraint": "3.49.0",
-        "@aws-sdk/middleware-logger": "3.49.0",
-        "@aws-sdk/middleware-retry": "3.49.0",
-        "@aws-sdk/middleware-sdk-s3": "3.49.0",
-        "@aws-sdk/middleware-serde": "3.49.0",
-        "@aws-sdk/middleware-signing": "3.49.0",
-        "@aws-sdk/middleware-ssec": "3.49.0",
-        "@aws-sdk/middleware-stack": "3.49.0",
-        "@aws-sdk/middleware-user-agent": "3.49.0",
-        "@aws-sdk/node-config-provider": "3.49.0",
-        "@aws-sdk/node-http-handler": "3.49.0",
-        "@aws-sdk/protocol-http": "3.49.0",
-        "@aws-sdk/smithy-client": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "@aws-sdk/url-parser": "3.49.0",
+        "@aws-sdk/client-sts": "3.50.0",
+        "@aws-sdk/config-resolver": "3.50.0",
+        "@aws-sdk/credential-provider-node": "3.50.0",
+        "@aws-sdk/eventstream-serde-browser": "3.50.0",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.50.0",
+        "@aws-sdk/eventstream-serde-node": "3.50.0",
+        "@aws-sdk/fetch-http-handler": "3.50.0",
+        "@aws-sdk/hash-blob-browser": "3.50.0",
+        "@aws-sdk/hash-node": "3.50.0",
+        "@aws-sdk/hash-stream-node": "3.50.0",
+        "@aws-sdk/invalid-dependency": "3.50.0",
+        "@aws-sdk/md5-js": "3.50.0",
+        "@aws-sdk/middleware-apply-body-checksum": "3.50.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.50.0",
+        "@aws-sdk/middleware-content-length": "3.50.0",
+        "@aws-sdk/middleware-expect-continue": "3.50.0",
+        "@aws-sdk/middleware-host-header": "3.50.0",
+        "@aws-sdk/middleware-location-constraint": "3.50.0",
+        "@aws-sdk/middleware-logger": "3.50.0",
+        "@aws-sdk/middleware-retry": "3.50.0",
+        "@aws-sdk/middleware-sdk-s3": "3.50.0",
+        "@aws-sdk/middleware-serde": "3.50.0",
+        "@aws-sdk/middleware-signing": "3.50.0",
+        "@aws-sdk/middleware-ssec": "3.50.0",
+        "@aws-sdk/middleware-stack": "3.50.0",
+        "@aws-sdk/middleware-user-agent": "3.50.0",
+        "@aws-sdk/node-config-provider": "3.50.0",
+        "@aws-sdk/node-http-handler": "3.50.0",
+        "@aws-sdk/protocol-http": "3.50.0",
+        "@aws-sdk/smithy-client": "3.50.0",
+        "@aws-sdk/types": "3.50.0",
+        "@aws-sdk/url-parser": "3.50.0",
         "@aws-sdk/util-base64-browser": "3.49.0",
         "@aws-sdk/util-base64-node": "3.49.0",
         "@aws-sdk/util-body-length-browser": "3.49.0",
         "@aws-sdk/util-body-length-node": "3.49.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.49.0",
-        "@aws-sdk/util-defaults-mode-node": "3.49.0",
-        "@aws-sdk/util-user-agent-browser": "3.49.0",
-        "@aws-sdk/util-user-agent-node": "3.49.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.50.0",
+        "@aws-sdk/util-defaults-mode-node": "3.50.0",
+        "@aws-sdk/util-user-agent-browser": "3.50.0",
+        "@aws-sdk/util-user-agent-node": "3.50.0",
         "@aws-sdk/util-utf8-browser": "3.49.0",
         "@aws-sdk/util-utf8-node": "3.49.0",
-        "@aws-sdk/util-waiter": "3.49.0",
+        "@aws-sdk/util-waiter": "3.50.0",
         "@aws-sdk/xml-builder": "3.49.0",
         "entities": "2.2.0",
         "fast-xml-parser": "3.19.0",
@@ -283,77 +283,77 @@
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.49.0.tgz",
-      "integrity": "sha512-rY8uZo4DeNwwKf+Sx0TX/5ysXJKf+0SQSCTWD9S4a0AjtiaLc6hKCX+sJY43VDHvNYieKtXLDYHBdhhqZKwG+g==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.50.0.tgz",
+      "integrity": "sha512-Nb/ATiiqOSZBZWqm8o20+z2Ep7V89gIZWupigDfft7gCeXdQ7dBACUGLsab6VKgqN6N6Ns+9Hg/2kncmwOaR2Q==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.49.0",
-        "@aws-sdk/fetch-http-handler": "3.49.0",
-        "@aws-sdk/hash-node": "3.49.0",
-        "@aws-sdk/invalid-dependency": "3.49.0",
-        "@aws-sdk/middleware-content-length": "3.49.0",
-        "@aws-sdk/middleware-host-header": "3.49.0",
-        "@aws-sdk/middleware-logger": "3.49.0",
-        "@aws-sdk/middleware-retry": "3.49.0",
-        "@aws-sdk/middleware-serde": "3.49.0",
-        "@aws-sdk/middleware-stack": "3.49.0",
-        "@aws-sdk/middleware-user-agent": "3.49.0",
-        "@aws-sdk/node-config-provider": "3.49.0",
-        "@aws-sdk/node-http-handler": "3.49.0",
-        "@aws-sdk/protocol-http": "3.49.0",
-        "@aws-sdk/smithy-client": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "@aws-sdk/url-parser": "3.49.0",
+        "@aws-sdk/config-resolver": "3.50.0",
+        "@aws-sdk/fetch-http-handler": "3.50.0",
+        "@aws-sdk/hash-node": "3.50.0",
+        "@aws-sdk/invalid-dependency": "3.50.0",
+        "@aws-sdk/middleware-content-length": "3.50.0",
+        "@aws-sdk/middleware-host-header": "3.50.0",
+        "@aws-sdk/middleware-logger": "3.50.0",
+        "@aws-sdk/middleware-retry": "3.50.0",
+        "@aws-sdk/middleware-serde": "3.50.0",
+        "@aws-sdk/middleware-stack": "3.50.0",
+        "@aws-sdk/middleware-user-agent": "3.50.0",
+        "@aws-sdk/node-config-provider": "3.50.0",
+        "@aws-sdk/node-http-handler": "3.50.0",
+        "@aws-sdk/protocol-http": "3.50.0",
+        "@aws-sdk/smithy-client": "3.50.0",
+        "@aws-sdk/types": "3.50.0",
+        "@aws-sdk/url-parser": "3.50.0",
         "@aws-sdk/util-base64-browser": "3.49.0",
         "@aws-sdk/util-base64-node": "3.49.0",
         "@aws-sdk/util-body-length-browser": "3.49.0",
         "@aws-sdk/util-body-length-node": "3.49.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.49.0",
-        "@aws-sdk/util-defaults-mode-node": "3.49.0",
-        "@aws-sdk/util-user-agent-browser": "3.49.0",
-        "@aws-sdk/util-user-agent-node": "3.49.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.50.0",
+        "@aws-sdk/util-defaults-mode-node": "3.50.0",
+        "@aws-sdk/util-user-agent-browser": "3.50.0",
+        "@aws-sdk/util-user-agent-node": "3.50.0",
         "@aws-sdk/util-utf8-browser": "3.49.0",
         "@aws-sdk/util-utf8-node": "3.49.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.49.0.tgz",
-      "integrity": "sha512-vqHNCuQriMZV1aeXc6cza5S9A/2zgfNiTelsmbDQdlCiZQ+YL3nTp1WFeYHap4ffYlLOAD0xv0yz/+naV4oHtQ==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.50.0.tgz",
+      "integrity": "sha512-v9VkuuwvejmSHBRl3tOnzcL1RrDZODlswLcCicHlB0H8W5XvQfeNlfe/0Io9M6cE/bfxAE4zuC6QhaFkyYHDQw==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.49.0",
-        "@aws-sdk/credential-provider-node": "3.49.0",
-        "@aws-sdk/fetch-http-handler": "3.49.0",
-        "@aws-sdk/hash-node": "3.49.0",
-        "@aws-sdk/invalid-dependency": "3.49.0",
-        "@aws-sdk/middleware-content-length": "3.49.0",
-        "@aws-sdk/middleware-host-header": "3.49.0",
-        "@aws-sdk/middleware-logger": "3.49.0",
-        "@aws-sdk/middleware-retry": "3.49.0",
-        "@aws-sdk/middleware-sdk-sts": "3.49.0",
-        "@aws-sdk/middleware-serde": "3.49.0",
-        "@aws-sdk/middleware-signing": "3.49.0",
-        "@aws-sdk/middleware-stack": "3.49.0",
-        "@aws-sdk/middleware-user-agent": "3.49.0",
-        "@aws-sdk/node-config-provider": "3.49.0",
-        "@aws-sdk/node-http-handler": "3.49.0",
-        "@aws-sdk/protocol-http": "3.49.0",
-        "@aws-sdk/smithy-client": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "@aws-sdk/url-parser": "3.49.0",
+        "@aws-sdk/config-resolver": "3.50.0",
+        "@aws-sdk/credential-provider-node": "3.50.0",
+        "@aws-sdk/fetch-http-handler": "3.50.0",
+        "@aws-sdk/hash-node": "3.50.0",
+        "@aws-sdk/invalid-dependency": "3.50.0",
+        "@aws-sdk/middleware-content-length": "3.50.0",
+        "@aws-sdk/middleware-host-header": "3.50.0",
+        "@aws-sdk/middleware-logger": "3.50.0",
+        "@aws-sdk/middleware-retry": "3.50.0",
+        "@aws-sdk/middleware-sdk-sts": "3.50.0",
+        "@aws-sdk/middleware-serde": "3.50.0",
+        "@aws-sdk/middleware-signing": "3.50.0",
+        "@aws-sdk/middleware-stack": "3.50.0",
+        "@aws-sdk/middleware-user-agent": "3.50.0",
+        "@aws-sdk/node-config-provider": "3.50.0",
+        "@aws-sdk/node-http-handler": "3.50.0",
+        "@aws-sdk/protocol-http": "3.50.0",
+        "@aws-sdk/smithy-client": "3.50.0",
+        "@aws-sdk/types": "3.50.0",
+        "@aws-sdk/url-parser": "3.50.0",
         "@aws-sdk/util-base64-browser": "3.49.0",
         "@aws-sdk/util-base64-node": "3.49.0",
         "@aws-sdk/util-body-length-browser": "3.49.0",
         "@aws-sdk/util-body-length-node": "3.49.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.49.0",
-        "@aws-sdk/util-defaults-mode-node": "3.49.0",
-        "@aws-sdk/util-user-agent-browser": "3.49.0",
-        "@aws-sdk/util-user-agent-node": "3.49.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.50.0",
+        "@aws-sdk/util-defaults-mode-node": "3.50.0",
+        "@aws-sdk/util-user-agent-browser": "3.50.0",
+        "@aws-sdk/util-user-agent-node": "3.50.0",
         "@aws-sdk/util-utf8-browser": "3.49.0",
         "@aws-sdk/util-utf8-node": "3.49.0",
         "entities": "2.2.0",
@@ -362,207 +362,207 @@
       }
     },
     "@aws-sdk/config-resolver": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.49.0.tgz",
-      "integrity": "sha512-4kYV+89E9MG+/wfPY3dmwqzquQxNd951jdfjQbSg1ii68X/owqmWda4bLulV0Z4iGUz9TXkbaJCWyRyjsFNe4w==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.50.0.tgz",
+      "integrity": "sha512-sLVbB2wLKR7xJ+E4NqbUeY2nUwqiKL8umSRBPYAs2NUBSIXhtlqhXveKt8DgKi+c06Gevcd6zbMiAWgAQhmCRQ==",
       "requires": {
-        "@aws-sdk/signature-v4": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/signature-v4": "3.50.0",
+        "@aws-sdk/types": "3.50.0",
         "@aws-sdk/util-config-provider": "3.49.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/credential-provider-env": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.49.0.tgz",
-      "integrity": "sha512-mx82N0un6URmmiM11X3ObK3ka5R99lEFdhwPc0jqsCPnXRVioUtK5DXkJ8FmgixbDcs5Pdij9A8MINSeBrG0bQ==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.50.0.tgz",
+      "integrity": "sha512-ZyFORU/soLC2R8kfIB8ppmmuCF+xkb2PAbSiGf1v7Q9OkqklIo9w4kJhEyV96UWgRy+dzBh9knIXJ6Ok/Tey2Q==",
       "requires": {
-        "@aws-sdk/property-provider": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/property-provider": "3.50.0",
+        "@aws-sdk/types": "3.50.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/credential-provider-imds": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.49.0.tgz",
-      "integrity": "sha512-d/H5VgmRiIupQdPg9QcX16kdvuiS/YytRYCQOncVstNXHvYZM9EgeIXJLXyPNaD2W8SS7CBf4KKWYJn3V+9AZw==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.50.0.tgz",
+      "integrity": "sha512-rB75qTBIqp5YbyQdGSIWHQAVofMaE0PV7Dg8EpIb5C2DuKVGfx+WhWgRjc0qo6JqUyDuq7mpccj4m5FXbxq8Cw==",
       "requires": {
-        "@aws-sdk/node-config-provider": "3.49.0",
-        "@aws-sdk/property-provider": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "@aws-sdk/url-parser": "3.49.0",
+        "@aws-sdk/node-config-provider": "3.50.0",
+        "@aws-sdk/property-provider": "3.50.0",
+        "@aws-sdk/types": "3.50.0",
+        "@aws-sdk/url-parser": "3.50.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.49.0.tgz",
-      "integrity": "sha512-QlWfxDwZVyX36pghgkKGBR+fBmX/mjmvc0kzxUmqGhUYAkDQ0YKR11ybpGBrxBKT4lIOE+9z6Tu4nLjp3OlJIg==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.50.0.tgz",
+      "integrity": "sha512-NOdlvH3nKOmJttXpcQr2zUKEoPg88e/fK1rXTK6/wcdHJqCKyFzb/o0jP9KucHOK2b5sQFJzeKDuHuUnmPhj5A==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.49.0",
-        "@aws-sdk/credential-provider-imds": "3.49.0",
-        "@aws-sdk/credential-provider-sso": "3.49.0",
-        "@aws-sdk/credential-provider-web-identity": "3.49.0",
-        "@aws-sdk/property-provider": "3.49.0",
+        "@aws-sdk/credential-provider-env": "3.50.0",
+        "@aws-sdk/credential-provider-imds": "3.50.0",
+        "@aws-sdk/credential-provider-sso": "3.50.0",
+        "@aws-sdk/credential-provider-web-identity": "3.50.0",
+        "@aws-sdk/property-provider": "3.50.0",
         "@aws-sdk/shared-ini-file-loader": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/types": "3.50.0",
         "@aws-sdk/util-credentials": "3.49.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.49.0.tgz",
-      "integrity": "sha512-DonoqOZHcqfNuwMG1fGJpHJTqf1QinihRKzlOoUWzmseqBCiuagGouSN7nOQgee5BrzF0X9/nao9lnPc4on2TA==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.50.0.tgz",
+      "integrity": "sha512-/14vPsKIE9ixXNl8Ur3K12dPcRli5ElIMJVWv6nW2bYPZLhKoKhHuSfDREci9nnIp2tDiTEjbTbpSH+iFa6gbw==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.49.0",
-        "@aws-sdk/credential-provider-imds": "3.49.0",
-        "@aws-sdk/credential-provider-ini": "3.49.0",
-        "@aws-sdk/credential-provider-process": "3.49.0",
-        "@aws-sdk/credential-provider-sso": "3.49.0",
-        "@aws-sdk/credential-provider-web-identity": "3.49.0",
-        "@aws-sdk/property-provider": "3.49.0",
+        "@aws-sdk/credential-provider-env": "3.50.0",
+        "@aws-sdk/credential-provider-imds": "3.50.0",
+        "@aws-sdk/credential-provider-ini": "3.50.0",
+        "@aws-sdk/credential-provider-process": "3.50.0",
+        "@aws-sdk/credential-provider-sso": "3.50.0",
+        "@aws-sdk/credential-provider-web-identity": "3.50.0",
+        "@aws-sdk/property-provider": "3.50.0",
         "@aws-sdk/shared-ini-file-loader": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/types": "3.50.0",
         "@aws-sdk/util-credentials": "3.49.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/credential-provider-process": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.49.0.tgz",
-      "integrity": "sha512-Zn7CJHoXln8O+yBKdTBvcwCz6GDh48s7HtIsqjoOrqoL0oZWhgy8gn8S9KQ+HIqpiO8N0lMMteXuPl5fbC2zGg==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.50.0.tgz",
+      "integrity": "sha512-N6ySdgYn5aNJaWeDfL5wNH5z2zqFJI4aKqiGw0EIxfk9t5VNoe9YTh7F8RNbqdc/qfjWOr5JDuDIfSZmI/oQrw==",
       "requires": {
-        "@aws-sdk/property-provider": "3.49.0",
+        "@aws-sdk/property-provider": "3.50.0",
         "@aws-sdk/shared-ini-file-loader": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/types": "3.50.0",
         "@aws-sdk/util-credentials": "3.49.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.49.0.tgz",
-      "integrity": "sha512-sFTqbQOyGR88K10Y1OgauEPKDmEibxtAkLSFjkJ6Yw/Jyp+lftchoa+TxRrNvDY1zjZX+XauVI6UmD5Pi4E1NQ==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.50.0.tgz",
+      "integrity": "sha512-sSIOeZLBfXOVkxaV01DEIWqXbwN8FmTZrTvflrTf018U8kq60G0bON5DMD3Ro5ry6vQJA4MOx9HffM8vsSwgiA==",
       "requires": {
-        "@aws-sdk/client-sso": "3.49.0",
-        "@aws-sdk/property-provider": "3.49.0",
+        "@aws-sdk/client-sso": "3.50.0",
+        "@aws-sdk/property-provider": "3.50.0",
         "@aws-sdk/shared-ini-file-loader": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/types": "3.50.0",
         "@aws-sdk/util-credentials": "3.49.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/credential-provider-web-identity": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.49.0.tgz",
-      "integrity": "sha512-mlIHUTn04unB0HEwEO12YIY5848uE9B+gYI+YwlNZ70KXGs3lj2horOgPgbxeIfulCVw0aRTKChUg2ActTosYg==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.50.0.tgz",
+      "integrity": "sha512-zaujz5di3UfNQVv0FUw0S5L1eHm4+thg4tlncaEASJoU9wLKnyGlcnNlqscJ0rBZzk7EdOuibX/nQCD9/tI8UA==",
       "requires": {
-        "@aws-sdk/property-provider": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/property-provider": "3.50.0",
+        "@aws-sdk/types": "3.50.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/eventstream-marshaller": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-marshaller/-/eventstream-marshaller-3.49.0.tgz",
-      "integrity": "sha512-EDE7aim4c/G9vCWE+jaHQNWHzrHgF1WlUEok1tgLj+fbvqKduDK/1SNleMZbMLC7tFRARN+KKFB0Ctegyp8j4w==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-marshaller/-/eventstream-marshaller-3.50.0.tgz",
+      "integrity": "sha512-LdKK8oomkyXY9SQY/CjziroagClC6fvPzNCfIONuLRQJs7msypP9HT7AC9TFqYIZI3FHo9uCWhj86BsS+yeAfg==",
       "requires": {
         "@aws-crypto/crc32": "2.0.0",
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/types": "3.50.0",
         "@aws-sdk/util-hex-encoding": "3.49.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/eventstream-serde-browser": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.49.0.tgz",
-      "integrity": "sha512-XHDHVGmxzEEXzHESzXYiycE3CxHLedBQljQPCIXKJkUhmwf84oUDB/cRsgWoOwOpcRQQBZGUPTPOOOHVWQOlZA==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.50.0.tgz",
+      "integrity": "sha512-0rqPBpd9rqbXJ78MWZvdp8SYhPFizgFl/XDDl7cdbqVFrfNuGYNf+9TELtHW0u6W/OqflU7JAHrIxUnFNQGiuA==",
       "requires": {
-        "@aws-sdk/eventstream-marshaller": "3.49.0",
-        "@aws-sdk/eventstream-serde-universal": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/eventstream-marshaller": "3.50.0",
+        "@aws-sdk/eventstream-serde-universal": "3.50.0",
+        "@aws-sdk/types": "3.50.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/eventstream-serde-config-resolver": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.49.0.tgz",
-      "integrity": "sha512-7xCaQGfZD0xLpWVUsGEQ2PDAkkfnl1gc10h4jLm0xtEGzr0x3B3fLrmDiZTz+wBxRRuCqjiaBaNuPT+HocGYmA==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.50.0.tgz",
+      "integrity": "sha512-aqsLCYJgTc3SJl37PD/YnugI2wlttQ4mn+iQQ6Bp0D1cTKIEi6ScP9XJWg6C7nBUXNI9fBj4kyw22/LomsOL5g==",
       "requires": {
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/types": "3.50.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/eventstream-serde-node": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.49.0.tgz",
-      "integrity": "sha512-hRZa1QSCtSve3vSgOxtGRn7nlOJFGzaov6hDj+bFEWY6ukHWtG9lbit6ECALcud4BjxvaJet37kqToxnpDFMuQ==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.50.0.tgz",
+      "integrity": "sha512-dFqEl/9ua7cQkS8bji3IsCiLAL0kZn6okN1NnjNYRQDzrmxhj3ugYvp1Y1Gz2SdQ94CnQww0vUH+RmAKslqPlw==",
       "requires": {
-        "@aws-sdk/eventstream-marshaller": "3.49.0",
-        "@aws-sdk/eventstream-serde-universal": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/eventstream-marshaller": "3.50.0",
+        "@aws-sdk/eventstream-serde-universal": "3.50.0",
+        "@aws-sdk/types": "3.50.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/eventstream-serde-universal": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.49.0.tgz",
-      "integrity": "sha512-oW/k0QdJTEwRLbdWpakIKABYKEOokBaPd+VSOYmCNceYPzv74RTDqlzTTRVIGj51Jp+Bm1af3l0k1cpjPDnWfQ==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.50.0.tgz",
+      "integrity": "sha512-0ExTqMrkMLZl8MqRsAgGsBMD29JmuJqyiZ3cuAxJ5Bo2YSXL284tBVCtmYRRdmCvLpmJX7juV0eVoEd98nlBww==",
       "requires": {
-        "@aws-sdk/eventstream-marshaller": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/eventstream-marshaller": "3.50.0",
+        "@aws-sdk/types": "3.50.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/fetch-http-handler": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.49.0.tgz",
-      "integrity": "sha512-ougJRsvoIGP0qTgHSGVF1B5Ui95Y/SP5CpY/y6B8vMGrwJ+MmvcCUE3Qd2UJGjO1PfUneno8PHK4u5x7hc2ceA==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.50.0.tgz",
+      "integrity": "sha512-2ntw0cvu/AYAthhhiMz9MlHQffVZbb0NqLwA72A+IBAQaI+jI3NxCWNIdPaowDWJ008ip5LCrXb7TpgX0wl65Q==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.49.0",
-        "@aws-sdk/querystring-builder": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/protocol-http": "3.50.0",
+        "@aws-sdk/querystring-builder": "3.50.0",
+        "@aws-sdk/types": "3.50.0",
         "@aws-sdk/util-base64-browser": "3.49.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/hash-blob-browser": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.49.0.tgz",
-      "integrity": "sha512-DLLP8dY0eYAXefJJzAYO1QxHW567MN4D2KDxyOKkWOVR2S6ZLgtJb24MhT9RpV3AOM/x686HOv5V4r1rPbuHhw==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.50.0.tgz",
+      "integrity": "sha512-r8xgdiqmxlhYmlUD2v2zfG5jQrWm9qesAIu3l0SR2ZTYlm4dg70KY8ek90SbkXCEWmelY3dv6zjsFL0oPcQtoQ==",
       "requires": {
         "@aws-sdk/chunked-blob-reader": "3.49.0",
         "@aws-sdk/chunked-blob-reader-native": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/types": "3.50.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/hash-node": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.49.0.tgz",
-      "integrity": "sha512-nRNCmSkcJOzWzKU6NihlKW/6H1HxaaBjUe9ETnwWIgwPC7NZ6IWtri48Cf7Itvveu3dln3ZM2WSXN20TlQpuBw==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.50.0.tgz",
+      "integrity": "sha512-g0rgNaGt2OkoypnIy81QUamgIgVEmNl3OPPv8Ug2xDu+HJJQ2q7kIRTdVd9NZr3cCUMP4hsaYtwBYA4QOvtvLg==",
       "requires": {
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/types": "3.50.0",
         "@aws-sdk/util-buffer-from": "3.49.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/hash-stream-node": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.49.0.tgz",
-      "integrity": "sha512-ZsqGEs3yp5YH5vk1LhpIiSAzNzXHW89DvKn+BSSiDPdufPdOjLks8wKIVhAUfADcJ+S/AATTAt4SoA4mD+IHvQ==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.50.0.tgz",
+      "integrity": "sha512-5Jc/J2LzqfAyDOKJ7GE1tJHdMvApJ6vDe/jHFndPrAr0a42uEANgUHqdoDy7PtMz77/yRYvWxsj9j/+0T2fZAg==",
       "requires": {
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/types": "3.50.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/invalid-dependency": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.49.0.tgz",
-      "integrity": "sha512-MXf/9l/Oiy+KGKDvInv0RT4rtS+iNftYRTlTmUn3RR74Kz8Fvw+O0RcUjzSrNn5SpjCf/UsGrF+KBTm2gFYQCA==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.50.0.tgz",
+      "integrity": "sha512-Eu/I0rFnCgA6InIQ3h4jDmdUpDrGGFZH84+mN+LcVavE+j84WRGb1VNWsEWori8is7bjuM7e7twOvNxJ6rDqTw==",
       "requires": {
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/types": "3.50.0",
         "tslib": "^2.3.0"
       }
     },
@@ -575,262 +575,262 @@
       }
     },
     "@aws-sdk/md5-js": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.49.0.tgz",
-      "integrity": "sha512-CJJxl7FfTNseaw3RAPmihpys1cfbCyg7sLTev6PncqBhoVl+5AWOoITeZj3azE3CKevY2V7PEdmHjzKRNLmcdA==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.50.0.tgz",
+      "integrity": "sha512-yO6ocDVq7Tk1tEzaikNk2qIEQ4yWOrwBJyOgH+vPPbiM0ldwgqK7dxjd0Y8vvACyCTLvqwUKwwMABudHREhR4w==",
       "requires": {
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/types": "3.50.0",
         "@aws-sdk/util-utf8-browser": "3.49.0",
         "@aws-sdk/util-utf8-node": "3.49.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-apply-body-checksum": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-apply-body-checksum/-/middleware-apply-body-checksum-3.49.0.tgz",
-      "integrity": "sha512-uNUETgYrOLCZNad+vVsTblTqzuaCVCt67o4VawsziR5QuOCxX/27Ni3x1VNtpI5pUhD8FiT/9/lBpcMTvCSIgA==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-apply-body-checksum/-/middleware-apply-body-checksum-3.50.0.tgz",
+      "integrity": "sha512-px5W7eq93cGbh8Eb23Hh8RK35uP54vy3NjjyyJCBtL4Yb/4UEgQJUwn1HMW6EAc0x3CEm1TQ2a05gTIeib6PcA==",
       "requires": {
         "@aws-sdk/is-array-buffer": "3.49.0",
-        "@aws-sdk/protocol-http": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/protocol-http": "3.50.0",
+        "@aws-sdk/types": "3.50.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.49.0.tgz",
-      "integrity": "sha512-6GK6BXNRRe+JpBUomW1Wrj7HGU3gdl9XvrQekj772kmiBLx/40ntAxZnhjFjkNKLy7IM+he8yygnEUhbV/dEmg==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.50.0.tgz",
+      "integrity": "sha512-GpdNIoD2WOQg8MSLIpwJVkyTcAJLpjOiAs7oKQmU+7NUcHDoq0KXfSKqScM1ig6LO77K1GZ0ka06Mlnd60q/SA==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/protocol-http": "3.50.0",
+        "@aws-sdk/types": "3.50.0",
         "@aws-sdk/util-arn-parser": "3.49.0",
         "@aws-sdk/util-config-provider": "3.49.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-content-length": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.49.0.tgz",
-      "integrity": "sha512-7IaghPT7X92gNoyn9LzZj4V5YpGPDCYQTWhpzZoIlw88vOR4I0zKg7jwYeElRoNfRCI4OYhF26ajKnNHzNMlbA==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.50.0.tgz",
+      "integrity": "sha512-vMvE4qFuquNApbJhJx2AFTlw8/XzhVthemUsPr5+/Np11ns5NdeNPOEg3DtA5kViLEk9p/mqHRBwzp5ef40xaw==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/protocol-http": "3.50.0",
+        "@aws-sdk/types": "3.50.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-expect-continue": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.49.0.tgz",
-      "integrity": "sha512-i0FMywhvCdn3+gPuUgtM0ZRd3xBHozropbhvs3fu9Y6g1/YiOgTYuVVqHtObvktVWCV72i8fTvn8TEkyFHRDYQ==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.50.0.tgz",
+      "integrity": "sha512-t/7UGPH+Z4lW33HMymSLMANmea0RpNubDfBOLtRdjlVMHgYMtIdeCI43EklW4a6+KJ4Sy68Nx8EQweOZB+UJBA==",
       "requires": {
-        "@aws-sdk/middleware-header-default": "3.49.0",
-        "@aws-sdk/protocol-http": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/middleware-header-default": "3.50.0",
+        "@aws-sdk/protocol-http": "3.50.0",
+        "@aws-sdk/types": "3.50.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-header-default": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-3.49.0.tgz",
-      "integrity": "sha512-3xRNPwFMWQqgGKgxDWMgQXNdIr4EVq5ltrLqwsZopXKZli9/fidOrDN9z9j4AW9YAXyEAYB0fscKT7LcsvxFZg==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-3.50.0.tgz",
+      "integrity": "sha512-jCo9pGAwGOIN7/RZc7MRgUKQxDc6msFDCu0c7E0n4Z7XdVmyJt2dfpiexE683Q+rv/6AE4KzI+QlYoMQYGLiGw==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/protocol-http": "3.50.0",
+        "@aws-sdk/types": "3.50.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-host-header": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.49.0.tgz",
-      "integrity": "sha512-5l1ILqHs2mGqNvJb5mRe7hHbTQOO292jghE/LItpNx2tiu7BBGzP1bslHcyEVYoRBX9Oqyfou7s9Ww2yBWtImQ==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.50.0.tgz",
+      "integrity": "sha512-y9n6o7PdGP608KuxJ4p3u6kcVVoG2cS1lF5e23s0ZfdtRvXHPjMDmfjBZRl4UQyZBQezKjIUcdX411j5lklcJA==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/protocol-http": "3.50.0",
+        "@aws-sdk/types": "3.50.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-location-constraint": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.49.0.tgz",
-      "integrity": "sha512-PUQr06/9XQP0JfUY6nFvK5HHcO4aQbzn/iKvB8dl471IXcKVLnJdB2OuIjUUW6fQbKX1K4xcDEifWTSMIECIlg==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.50.0.tgz",
+      "integrity": "sha512-vlg3VXoddorADHpX1VeGkBge+eeSoOxC6nvB5CZbpY66QVhOzGrnwdQhNaZ72ZyqMBN5tlkRTSmzh3dNG7bgPw==",
       "requires": {
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/types": "3.50.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-logger": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.49.0.tgz",
-      "integrity": "sha512-OicQ0w5sCJXgpeZ+t3XeJA2R/09YfuSe53Ma6aWZm/2/r8vG/SW0yAnwFvwJeCm3DKtBxU1qO2eWhFqvJuWRVA==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.50.0.tgz",
+      "integrity": "sha512-kAEyl3wmFz3NgUvqC5bqiIWNV72sIuxqIWVeDWk3bAQylXAEa1kGaCgxNtY7Toz1dXk4rKagSa/hSIGNwgMm4A==",
       "requires": {
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/types": "3.50.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-retry": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.49.0.tgz",
-      "integrity": "sha512-RSS4R4PNULHA1b1eYR50YPPfOV2jRuXgLNLVVYMEzzC23MabKEXJYPge+pI1Q9rRrbahVj7aQcOTSpT0MsiEeA==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.50.0.tgz",
+      "integrity": "sha512-JNuTITuG3Z+Jtk2bavWys9tL3fZL9vap6ChWCc9M7+yafeuHftqV256eqSUH3aPaJFQZivbPT6BmSXEtqLPm2A==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.49.0",
-        "@aws-sdk/service-error-classification": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/protocol-http": "3.50.0",
+        "@aws-sdk/service-error-classification": "3.50.0",
+        "@aws-sdk/types": "3.50.0",
         "tslib": "^2.3.0",
         "uuid": "^8.3.2"
       }
     },
     "@aws-sdk/middleware-sdk-s3": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.49.0.tgz",
-      "integrity": "sha512-PeQHJsecGCnXILgOPLgcoZXCa4+2bctus2krhN08ES5oh1obeQB+EOC4v1sWV0DdfyTHEZMDSVLS9qTFHl9IUA==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.50.0.tgz",
+      "integrity": "sha512-RH9XwgrLYOli8hvnxs4HZqDvWMc9hQSNPJEgeEAnzEf0N84shSI/zRabCc7N0KDFjioxBtQkIcB3BWNHDIM8gg==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.49.0",
-        "@aws-sdk/signature-v4": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/protocol-http": "3.50.0",
+        "@aws-sdk/signature-v4": "3.50.0",
+        "@aws-sdk/types": "3.50.0",
         "@aws-sdk/util-arn-parser": "3.49.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-sdk-sts": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.49.0.tgz",
-      "integrity": "sha512-ZnLV37HKpMdK2x+69ZNqAqKr8rmweyMc//yZQRLtUKpKyQ/XSr0/KUBZXkgIny27aaBsrkplA5g1X2GrClRRZA==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.50.0.tgz",
+      "integrity": "sha512-o0SqaYs8TrPkm4G356GY9gucvwI2gCMxw7MAhm0tmfQu8ZL4RyNzsnGZmhgFbmpw59vJ9RxIAA8zwiKR2gI9lw==",
       "requires": {
-        "@aws-sdk/middleware-signing": "3.49.0",
-        "@aws-sdk/property-provider": "3.49.0",
-        "@aws-sdk/protocol-http": "3.49.0",
-        "@aws-sdk/signature-v4": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/middleware-signing": "3.50.0",
+        "@aws-sdk/property-provider": "3.50.0",
+        "@aws-sdk/protocol-http": "3.50.0",
+        "@aws-sdk/signature-v4": "3.50.0",
+        "@aws-sdk/types": "3.50.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-serde": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.49.0.tgz",
-      "integrity": "sha512-bMAlwR19uFUZ4om+U+/vnPvkcyYw83HdtERF9wrjAqNUnqYsifA0xn4R7Sakg6CW8V0h82dsST6zVfmHd+E2VA==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.50.0.tgz",
+      "integrity": "sha512-z8u2/setFnkjyh5jVNjZuwSjJRRZoE1JbueVqXj7HKVRBUcaofwutSi6C5e7Vtfr2Q+n/yTF5sUX9gcuPgTU0A==",
       "requires": {
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/types": "3.50.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-signing": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.49.0.tgz",
-      "integrity": "sha512-9p0xZjxV9zEQdOpA4MtzmblPRUgchevg5Q70E23yAU/Wjwzwf/6J93cUxdcS8HnmOIl0zQjJaYMTcBsvgJF1eg==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.50.0.tgz",
+      "integrity": "sha512-sokzKMuMCBGZJki5i0fO8F7QIlb7AjzQZ0585QD11HFQvt1v2uVTfKQ0rhJ90ayR+tDKTdv2iF2JTOVaMTkYlQ==",
       "requires": {
-        "@aws-sdk/property-provider": "3.49.0",
-        "@aws-sdk/protocol-http": "3.49.0",
-        "@aws-sdk/signature-v4": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/property-provider": "3.50.0",
+        "@aws-sdk/protocol-http": "3.50.0",
+        "@aws-sdk/signature-v4": "3.50.0",
+        "@aws-sdk/types": "3.50.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-ssec": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.49.0.tgz",
-      "integrity": "sha512-S7hfgOCYoqPe4YegSnwhQJ0KBVEhP6dIp7yLa1/yCJkqW2KSnLTvg6ao9vEFf/lhctZ72YZjm8v/2siXWCnDEA==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.50.0.tgz",
+      "integrity": "sha512-HQuadcnIGrBxsgCoc5BJ1SxjIxxXeB+GgwwLcsvRD3+YHyhT19gVTc4aPMpZYG9l0BFCSipnXppaIjJLpeJrSg==",
       "requires": {
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/types": "3.50.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-stack": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.49.0.tgz",
-      "integrity": "sha512-OZxs2P7EH58gkvkTI7ESlUPGam0TkE0ZxOX35KjCOcYMuWvTMshKBzHRLX64nz3DYdaHSIGHgB1v8LKELZjltw==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.50.0.tgz",
+      "integrity": "sha512-bnWnNz/KWMI0DT7neTV08oDyGEa4FUUpVS3xtL0JpYuUT8+k+9NlaR3DW5hWzKWKOXAV9LVx5GTyetZjXtwp/A==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-user-agent": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.49.0.tgz",
-      "integrity": "sha512-uAcKgafZ12L8UnyeQGgSFtwOKUfiBWDLt4P2fEHvZRz/HAIcK4pu1PXPArjwteinhUiCDNFfPw8hAPvstMoG6w==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.50.0.tgz",
+      "integrity": "sha512-djHWGzHyXNwJVTGEJ3xKNXr3s0XKfnVLq+B+isqNvR2Z42XdXd/ke1xZ+ZLcwO6dfZ5D7oUPtYJHTmBAZet3aQ==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/protocol-http": "3.50.0",
+        "@aws-sdk/types": "3.50.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/node-config-provider": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.49.0.tgz",
-      "integrity": "sha512-OCn5c6M/RJDEO80Q+Iy4ADSYgqd/uyEsvp+7lU4di4bMND9kYT4JO2ky2SWjIuARGq/mhMOhaN2DO9MbcqV20g==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.50.0.tgz",
+      "integrity": "sha512-0rdC5oWhOMVfsDK1pRgkujZTCgkr19fxVnLsF3z0XWSXkT13KKWru8rIVbM5ETuQ6U2NdMgcltA8osOFKizkbQ==",
       "requires": {
-        "@aws-sdk/property-provider": "3.49.0",
+        "@aws-sdk/property-provider": "3.50.0",
         "@aws-sdk/shared-ini-file-loader": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/types": "3.50.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/node-http-handler": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.49.0.tgz",
-      "integrity": "sha512-t7D9hoSigBihC9RRgYrkzgSER0fYzZe7192pJAaP6jk13ZOpccQRfXZoKge/cm42aHJsTy8DdQdGtLg7wLTp0g==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.50.0.tgz",
+      "integrity": "sha512-k7/A8yzIyq1NEWfuv/HprJs8kHXVSLKxWRDS6aEE92wyMFs8o/B+E7MEVeuYbldvpBU0GDg8ZbAYLX2yIxQj+A==",
       "requires": {
-        "@aws-sdk/abort-controller": "3.49.0",
-        "@aws-sdk/protocol-http": "3.49.0",
-        "@aws-sdk/querystring-builder": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/abort-controller": "3.50.0",
+        "@aws-sdk/protocol-http": "3.50.0",
+        "@aws-sdk/querystring-builder": "3.50.0",
+        "@aws-sdk/types": "3.50.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/property-provider": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.49.0.tgz",
-      "integrity": "sha512-6D48YpriOUpniezVuRI8J+MG+vgwb5C1SzBdgN4+S6DqbsEZy+kdEubXdoMICEd+Z8h7lH3p5zMr6po0icGCfA==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.50.0.tgz",
+      "integrity": "sha512-mY59kMP7QGNO19mxz+bAuvwEOeGwD7Dy/CeG3qGSGnEUrymjyPt31R+ptaZpE2gP5/ZEGBohbmDZag0l6sQyxg==",
       "requires": {
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/types": "3.50.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/protocol-http": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.49.0.tgz",
-      "integrity": "sha512-lb9CO7/vm26v4UwveWb4jSapqWWP/p0b9SuHpRExq+yMuvHqwxcoGrxmvS7FsanWbepRF1895dxU/Ar6/4pviA==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.50.0.tgz",
+      "integrity": "sha512-o6/eoDqjNRIKq6Zp5ujS6oP/GhQRzqvEsvWgKXHMVEMPmr9jkyQEdOqs4eWQ0+eRKJYhhWU3Perd6B+8z7BC1Q==",
       "requires": {
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/types": "3.50.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/querystring-builder": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.49.0.tgz",
-      "integrity": "sha512-+NlgIYihVyUetZcrF1ADY0eg8WW1/ETD5bzTwguTiKduXVHmavSakXK1jJF5vg05mefljToZXjQnOaEs9+K9LA==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.50.0.tgz",
+      "integrity": "sha512-2p9dt38qsWTo6iIdlIbsatNP8frEH0uqBcehJErX48UFhdeuRpy5E75c4Y9nRcqK2dZLpJ1ph+IiOiJEi28ZPg==",
       "requires": {
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/types": "3.50.0",
         "@aws-sdk/util-uri-escape": "3.49.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/querystring-parser": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.49.0.tgz",
-      "integrity": "sha512-4bSCHI5A8wi+JjsD1gAhMuGRGjDmlw6MoMWUiv4R2J8Ow/9mV8biKRo2ZytUPiSSu4G5JQ7mEkqFsm/VgkstDQ==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.50.0.tgz",
+      "integrity": "sha512-7bDwE4oAT1R78s7qvQsfuzMN0mKe86wWApUe7FPBitpcxstQhTRF3w+fuAwjJCxEQ/Dq/yYzYN1BNELLCon19Q==",
       "requires": {
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/types": "3.50.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/s3-request-presigner": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.49.0.tgz",
-      "integrity": "sha512-kFLEt2m4Iql4HhF6jdHD9dSMbD48ldYEYTsLThk8zGuepDs7k9md3QziMY1g47LMX+f9rSGLKBLMtfNvArG6JQ==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.50.0.tgz",
+      "integrity": "sha512-katK9JDN0BwU2g2VAMNGN4nO8JgQsYKyGl4x/D386QdyxcVQbveQ/Luro/eFkGof1/KJ/DgjlALGXhdjII1mKg==",
       "requires": {
-        "@aws-sdk/middleware-sdk-s3": "3.49.0",
-        "@aws-sdk/protocol-http": "3.49.0",
-        "@aws-sdk/signature-v4": "3.49.0",
-        "@aws-sdk/smithy-client": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
-        "@aws-sdk/util-create-request": "3.49.0",
-        "@aws-sdk/util-format-url": "3.49.0",
+        "@aws-sdk/middleware-sdk-s3": "3.50.0",
+        "@aws-sdk/protocol-http": "3.50.0",
+        "@aws-sdk/signature-v4": "3.50.0",
+        "@aws-sdk/smithy-client": "3.50.0",
+        "@aws-sdk/types": "3.50.0",
+        "@aws-sdk/util-create-request": "3.50.0",
+        "@aws-sdk/util-format-url": "3.50.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/service-error-classification": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.49.0.tgz",
-      "integrity": "sha512-iVmf7RcrIsM/We5ip8fe14RzEpSLF5eN8oqhCMftEdmMVnOYMd/9x0f1w69fbyBJNIIpyREqM8eAKz5OWQn5/g=="
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.50.0.tgz",
+      "integrity": "sha512-w3ZrVnBfNTOH2B4SNgtGT/oUuQhNTONDgVZxDdIj0AXLEV7qAipI8bU32SMXTx1Lds7gaqysKsWw5F/Bc5MlLg=="
     },
     "@aws-sdk/shared-ini-file-loader": {
       "version": "3.49.0",
@@ -841,39 +841,39 @@
       }
     },
     "@aws-sdk/signature-v4": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.49.0.tgz",
-      "integrity": "sha512-mQSGclWmv/9/MsgthBuKMHN6nkkhGTLXspkhqJ9xSUhjhoaHQVwMoJc39PowJGbYFn1AtCvHAqJtFXTGsMRwPA==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.50.0.tgz",
+      "integrity": "sha512-NEYqyKjq453Aqv1fBMj8bLwf/Rus6IxY1YpbeCMtZOPlTxHg9KPWd7GzjIFP4AbD1iksxqtBO+C5mFLcejYNUA==",
       "requires": {
         "@aws-sdk/is-array-buffer": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/types": "3.50.0",
         "@aws-sdk/util-hex-encoding": "3.49.0",
         "@aws-sdk/util-uri-escape": "3.49.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/smithy-client": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.49.0.tgz",
-      "integrity": "sha512-ANh9SlEvuru1DcalVoQ7K6wSCYuw4jyeTsIDsJSa13ckrmXAg+ql9vq61ELAXTSNVmuAISuuPjbVaWvOYCtdCQ==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.50.0.tgz",
+      "integrity": "sha512-0pX4GNONWS5PqJwAfJH0E3fdzvqhtfwPPhq2ZiFCx7wTir9Y3R4dKMbeeXUf7QsjZzC41Nz9/7xYsSjPsMRKAA==",
       "requires": {
-        "@aws-sdk/middleware-stack": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/middleware-stack": "3.50.0",
+        "@aws-sdk/types": "3.50.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/types": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.49.0.tgz",
-      "integrity": "sha512-8bCqEpquTlPN6xkjaJ+s+RoEFIu5r4G8oXOsQ5HYBvBdpx62HnCqzHLFNHycL2b8sE+VysQgNvmdQYR98vdMGQ=="
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.50.0.tgz",
+      "integrity": "sha512-ANj9L+lR4NWWSLPkr5tRdFaw0kW0BjlDgnyNWyFrGVOHqT0MYjhCjPsH2y45G59z+b2qe+v/VsKuTyNmSvoZCA=="
     },
     "@aws-sdk/url-parser": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.49.0.tgz",
-      "integrity": "sha512-l5td6eu+sIjzNsZYVGr7Mz6vssf2j/8/QrrTYF76J2R6OoceCsKdyJgJPP/tXBdcp4HUZDdVcMqtWRbxGC4izQ==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.50.0.tgz",
+      "integrity": "sha512-dyexaE+SJpN8Cf9nm3Uslo9eySjA9B22Mb/lw7XLgG58IxMmvj6+IjphV0/uIqj3CJ5OS7B7r5RCc5xqZwhCqg==",
       "requires": {
-        "@aws-sdk/querystring-parser": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/querystring-parser": "3.50.0",
+        "@aws-sdk/types": "3.50.0",
         "tslib": "^2.3.0"
       }
     },
@@ -936,13 +936,13 @@
       }
     },
     "@aws-sdk/util-create-request": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-create-request/-/util-create-request-3.49.0.tgz",
-      "integrity": "sha512-iFU2NVQHXIcSknCSLVSo0YNO8H5IiFjAm9NYUeMI+c+cROfyuOhqfahEQPpTZLjMR8z64imSZlICRY6i858EXQ==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-create-request/-/util-create-request-3.50.0.tgz",
+      "integrity": "sha512-6WtnVo+tjnqk2BH92y1TRSX+9UuohdvUFTZLR/sCHuh4r2Mh/ghCJE7Vl77voR+DHk+SJI/G/1DiHhcfVMsTAw==",
       "requires": {
-        "@aws-sdk/middleware-stack": "3.49.0",
-        "@aws-sdk/smithy-client": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/middleware-stack": "3.50.0",
+        "@aws-sdk/smithy-client": "3.50.0",
+        "@aws-sdk/types": "3.50.0",
         "tslib": "^2.3.0"
       }
     },
@@ -956,36 +956,36 @@
       }
     },
     "@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.49.0.tgz",
-      "integrity": "sha512-MNOvFET5TNBHgvsmfcLuxVDDUV0OIjE1lxrdbXWol7bMgLc2uL3/QOXWKCOUzcFCqTOnWCvbnwkOjs3f7Dpzmw==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.50.0.tgz",
+      "integrity": "sha512-W5WMC+3IHshIEK3WePHoI64B06IWqBLIxZbzlC9ewu/VDOEH0Uxt4UyQBdwh08Ip6SgLLfnG2dHWu6DaYCrepw==",
       "requires": {
-        "@aws-sdk/property-provider": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/property-provider": "3.50.0",
+        "@aws-sdk/types": "3.50.0",
         "bowser": "^2.11.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-defaults-mode-node": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.49.0.tgz",
-      "integrity": "sha512-bd5/ZJlNIX25n83mvcCh9eYQiDdf6gLHNH6ZftA/EbFfkE0o/qHrFhBhiB9HBY9ZoHhtoqrJNv5W9qKFHx1EIA==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.50.0.tgz",
+      "integrity": "sha512-He1H/SpT6LMOfGL4+veRCS0MbjmeyEOUapgV25NSWX+tkbzYQtkqCWVhDXI8OvOmB90G89reNIH8MRgTqui8wA==",
       "requires": {
-        "@aws-sdk/config-resolver": "3.49.0",
-        "@aws-sdk/credential-provider-imds": "3.49.0",
-        "@aws-sdk/node-config-provider": "3.49.0",
-        "@aws-sdk/property-provider": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/config-resolver": "3.50.0",
+        "@aws-sdk/credential-provider-imds": "3.50.0",
+        "@aws-sdk/node-config-provider": "3.50.0",
+        "@aws-sdk/property-provider": "3.50.0",
+        "@aws-sdk/types": "3.50.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-format-url": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.49.0.tgz",
-      "integrity": "sha512-8033WCPOtUfue7QpqDkjFBAsMuy9+VcXtnNQQG4+NNbEjGYsAp2qomUwGstM7qDfoMA4OuCDGF0jlXIF5ghwBQ==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.50.0.tgz",
+      "integrity": "sha512-vOTTtPWhzm8Peyp7ibrxOTFU575HzV2YYUYZG0pQ07m1D2ohTn/Mprrh069/qYD2+7Yyl5tD5tb7l/O/FKro/w==",
       "requires": {
-        "@aws-sdk/querystring-builder": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/querystring-builder": "3.50.0",
+        "@aws-sdk/types": "3.50.0",
         "tslib": "^2.3.0"
       }
     },
@@ -1014,22 +1014,22 @@
       }
     },
     "@aws-sdk/util-user-agent-browser": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.49.0.tgz",
-      "integrity": "sha512-RR4E6WlDSu9SivPjx/Jddo87PeVg6dhRL0XGdDBpew7i8bfwqCvxQydkbWIetxucLrt9zII9QnLDQUPBue1xUw==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.50.0.tgz",
+      "integrity": "sha512-QKbR/4bqq1ZAL1e+R8LHbiHPnoszBJ1rQDETj+Mu75hal7ZQ0K4MMNpNnH0tp+ZXh+i0JfUltROH37nPe4K7MQ==",
       "requires": {
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/types": "3.50.0",
         "bowser": "^2.11.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-user-agent-node": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.49.0.tgz",
-      "integrity": "sha512-ixUkF6kcDfsWO0kivyOKAnBITJm7InGa04ALbgAfuuE7RU1cVkXVMFIn5vux7QkziK7+JwozM9SNPIwNukElDw==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.50.0.tgz",
+      "integrity": "sha512-bzFmU0E0+/pgmaa2V4MVxS8Y16+Wkup/mOrGwJ6oHkGwYNIZeDEQDTLLjBgG3nLO2YTF8DhogPcyifowibkD1A==",
       "requires": {
-        "@aws-sdk/node-config-provider": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/node-config-provider": "3.50.0",
+        "@aws-sdk/types": "3.50.0",
         "tslib": "^2.3.0"
       }
     },
@@ -1051,12 +1051,12 @@
       }
     },
     "@aws-sdk/util-waiter": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.49.0.tgz",
-      "integrity": "sha512-eKrKOLcIhjA/MyjIfwgLL6ZUfGYf6VxBXryuRf8CmJKAo71ZO6ipAsy1X3uYrfwQQBMKV4VZu48BJx5PUBM7GA==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.50.0.tgz",
+      "integrity": "sha512-dLDLUFGx8yTpX90TOo0tOQ+0fwp4LZHHoZmvM+O2OmcCUq/Yl+Esk0FkWMVjAQuMacsvUHX8kH04tia20wMUDQ==",
       "requires": {
-        "@aws-sdk/abort-controller": "3.49.0",
-        "@aws-sdk/types": "3.49.0",
+        "@aws-sdk/abort-controller": "3.50.0",
+        "@aws-sdk/types": "3.50.0",
         "tslib": "^2.3.0"
       }
     },
@@ -1260,9 +1260,9 @@
       "dev": true
     },
     "@nimbella/nimbella-deployer": {
-      "version": "3.1.12",
-      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-3.1.12.tgz",
-      "integrity": "sha512-LPhFtALm95RZIrFsh9rdRcYNf5efn95OycC/5xbhpmVvUZsP8zXoZHQm5F0aqHaKVDI8/1c6kJbD3X/PkYlCdg==",
+      "version": "3.1.14",
+      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-3.1.14.tgz",
+      "integrity": "sha512-PQ7jkQ9RizUEMl9m3JL0DlTzg7ImnotMZv5t+QXmRV46UFrUcRTGoiYoEmU/jJdY6ksTizcYGXsLMJ4iFeH3UA==",
       "requires": {
         "@nimbella/sdk": "^1.3.5",
         "@nimbella/storage": "^0.0.7",
@@ -3694,9 +3694,9 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "follow-redirects": {
-      "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
+      "version": "1.14.8",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
+      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA=="
     },
     "fs-constants": {
       "version": "1.0.0",
@@ -3912,9 +3912,9 @@
       }
     },
     "google-auth-library": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.11.0.tgz",
-      "integrity": "sha512-3S5jn2quRumvh9F/Ubf7GFrIq71HZ5a6vqosgdIu105kkk0WtSqc2jGCRqtWWOLRS8SX3AHACMOEDxhyWAQIcg==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.12.0.tgz",
+      "integrity": "sha512-RS/whvFPMoF1hQNxnoVET3DWKPBt1Xgqe2rY0k+Jn7TNhoHlwdnSe7Rlcbo2Nub3Mt2lUVz26X65aDQrWp6x8w==",
       "requires": {
         "arrify": "^2.0.0",
         "base64-js": "^1.3.0",
@@ -3941,12 +3941,12 @@
       "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ=="
     },
     "gtoken": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.3.1.tgz",
-      "integrity": "sha512-yqOREjzLHcbzz1UrQoxhBtpk8KjrVhuqPE7od1K2uhyxG2BHjKZetlbLw/SPZak/QqTIQW+addS+EcjqQsZbwQ==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.3.2.tgz",
+      "integrity": "sha512-gkvEKREW7dXWF8NV8pVrKfW7WqReAmjjkMBh6lNCCGOM4ucS0r0YyXXl0r/9Yj8wcW/32ISkfc8h5mPTDbtifQ==",
       "requires": {
         "gaxios": "^4.0.0",
-        "google-p12-pem": "^3.0.3",
+        "google-p12-pem": "^3.1.3",
         "jws": "^4.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@adobe/aio-cli-plugin-runtime": "github:nimbella/aio-cli-plugin-runtime#v2021-11-19-1",
     "@adobe/aio-lib-core-config": "^2.0.0",
     "@adobe/aio-lib-runtime": "^2.0.0",
-    "@nimbella/nimbella-deployer": "^3.1.12",
+    "@nimbella/nimbella-deployer": "^3.1.14",
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "chalk": "^4.1.0",


### PR DESCRIPTION
1. Correct error message when --remote-build combined with missing
symbols in project.yml.
2. Propagate a global environment correctly on remote build.
3. Show error rather than ignore when parameters/environment adhere to
the default package (this package is not real and the result will not
be as expected).