### PR TITLE
Add a test to remote-build-go that exercises dep downloading

### DIFF
--- a/tests/remote-build-go/packages/test-remote-build-go/dependencies/go.mod
+++ b/tests/remote-build-go/packages/test-remote-build-go/dependencies/go.mod
@@ -1,0 +1,5 @@
+module dependencies
+
+go 1.15
+
+require github.com/pkg/errors v0.9.1

--- a/tests/remote-build-go/packages/test-remote-build-go/dependencies/main.go
+++ b/tests/remote-build-go/packages/test-remote-build-go/dependencies/main.go
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import _ "github.com/pkg/errors"
+
+func Main(args map[string]interface{}) map[string]interface{} {
+	name, ok := args["name"].(string)
+	if !ok {
+		name = "stranger"
+	}
+	msg := make(map[string]interface{})
+	msg["body"] = "Hello, " + name + "!"
+	return msg
+}

--- a/tests/remote-build-go/project.yml
+++ b/tests/remote-build-go/project.yml
@@ -3,4 +3,6 @@ packages:
     actions:
       - name: explicit
         file: packages/test-remote-build-go/default.go
-        runtime: 'go:1.12'
+        runtime: 'go:1.15'
+      - name: dependencies
+        runtime: 'go:default'

--- a/tests/remote-build-go/test.bats
+++ b/tests/remote-build-go/test.bats
@@ -8,10 +8,12 @@ teardown_file() {
   run $NIM project deploy $BATS_TEST_DIRNAME --remote-build
 	assert_success
 	assert_line -p "Submitted action 'default' for remote building and deployment in runtime go:default"
-	assert_line -p "Submitted action 'explicit' for remote building and deployment in runtime go:1.12"
+	assert_line -p "Submitted action 'dependencies' for remote building and deployment in runtime go:default"
+	assert_line -p "Submitted action 'explicit' for remote building and deployment in runtime go:1.15"
 }
 
 @test "invoke remotely built go lang actions" {
 	test_binary_action test-remote-build-go/default "Hello, stranger!"
 	test_binary_action test-remote-build-go/explicit "Hello, stranger!"
+	test_binary_action test-remote-build-go/dependencies "Hello, stranger!"
 }


### PR DESCRIPTION
As per title. This is an important flow to run in the context of limiting where users can or cannot write inside of the container.