### PR TITLE
Add a test for remote builds of Node.js actions

### DIFF
--- a/tests/remote-build-nodejs/packages/test-remote-build-nodejs/default/main.js
+++ b/tests/remote-build-nodejs/packages/test-remote-build-nodejs/default/main.js
@@ -1,0 +1,8 @@
+const { ToWords } = require('to-words');
+
+function main() {
+    const toWords = new ToWords();
+    return {"body": toWords.convert(9999)}
+}
+
+exports.main = main;

--- a/tests/remote-build-nodejs/packages/test-remote-build-nodejs/default/package.json
+++ b/tests/remote-build-nodejs/packages/test-remote-build-nodejs/default/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "something",
+    "version": "1.0.0",
+    "main": "main.js",
+    "dependencies": {
+        "to-words": "^3.1.0"
+    }
+}

--- a/tests/remote-build-nodejs/test.bats
+++ b/tests/remote-build-nodejs/test.bats
@@ -1,0 +1,15 @@
+load ../test_setup.bash
+
+teardown_file() {
+	delete_package "test-remote-build-nodejs"
+}
+
+@test "deploy nodejs projects with remote build" {
+  run $NIM project deploy $BATS_TEST_DIRNAME --remote-build
+	assert_success
+	assert_line -p "Submitted action 'default' for remote building and deployment in runtime nodejs:default"
+}
+
+@test "invoke remotely built nodejs lang actions" {
+	test_binary_action test-remote-build-nodejs/default "Nine Thousand Nine Hundred Ninety Nine"
+}


### PR DESCRIPTION
A gap in our testing currently.