### PR TITLE
Project create should check that a runtime exists for a project before creating it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@adobe/aio-cli-plugin-runtime": "github:nimbella/aio-cli-plugin-runtime#v2021-11-19-1",
         "@adobe/aio-lib-core-config": "^2.0.0",
-        "@nimbella/nimbella-deployer": "^3.1.20",
+        "@nimbella/nimbella-deployer": "^3.1.21",
         "@nimbella/storage": "^0.0.7",
         "@oclif/command": "^1",
         "@oclif/config": "^1",
@@ -1731,9 +1731,9 @@
       "dev": true
     },
     "node_modules/@nimbella/nimbella-deployer": {
-      "version": "3.1.20",
-      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-3.1.20.tgz",
-      "integrity": "sha512-F1n+xWE+6iwwTJw5lBkLfRZSnooZXHdT37SfpQhRnJduSMd391ei6qlbyKaw1ERnoQ2up9l+45YDYiFe7Dlg8A==",
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-3.1.21.tgz",
+      "integrity": "sha512-uM2GFz5rEG11XqZlkKah+1pVvvBqUht4JcXhMg6y95oZ5ysNeSsrMpD+t2zP3djDYzGFkeU0eqYsj4M+mEc3SQ==",
       "dependencies": {
         "@nimbella/sdk": "^1.3.5",
         "@nimbella/storage": "^0.0.7",
@@ -11489,9 +11489,9 @@
       "dev": true
     },
     "@nimbella/nimbella-deployer": {
-      "version": "3.1.20",
-      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-3.1.20.tgz",
-      "integrity": "sha512-F1n+xWE+6iwwTJw5lBkLfRZSnooZXHdT37SfpQhRnJduSMd391ei6qlbyKaw1ERnoQ2up9l+45YDYiFe7Dlg8A==",
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-3.1.21.tgz",
+      "integrity": "sha512-uM2GFz5rEG11XqZlkKah+1pVvvBqUht4JcXhMg6y95oZ5ysNeSsrMpD+t2zP3djDYzGFkeU0eqYsj4M+mEc3SQ==",
       "requires": {
         "@nimbella/sdk": "^1.3.5",
         "@nimbella/storage": "^0.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nimbella/nimbella-cli",
-  "version": "2.3.7",
+  "version": "2.3.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nimbella/nimbella-cli",
-      "version": "2.3.7",
+      "version": "2.3.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/aio-cli-plugin-runtime": "github:nimbella/aio-cli-plugin-runtime#v2021-11-19-1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@adobe/aio-cli-plugin-runtime": "github:nimbella/aio-cli-plugin-runtime#v2021-11-19-1",
     "@adobe/aio-lib-core-config": "^2.0.0",
-    "@nimbella/nimbella-deployer": "^3.1.20",
+    "@nimbella/nimbella-deployer": "^3.1.21",
     "@nimbella/storage": "^0.0.7",
     "@oclif/command": "^1",
     "@oclif/config": "^1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/nimbella-cli",
-  "version": "2.3.7",
+  "version": "2.3.8",
   "description": "A comprehensive CLI for the Nimbella stack",
   "main": "lib/index.js",
   "repository": {

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -35,13 +35,11 @@ export default class Info extends NimBaseCommand {
       await this.displayAncillary('license', logger)
     } else if (flags.changes && !inBrowser) {
       await this.displayAncillary('changes', logger)
-    } else if (flags.runtimes || flags.limits) {
+    } else if (flags.runtimes) {
+      await this.displayRuntimes(logger)
+    } else if (flags.limits) {
       const sysinfo = await this.getSystemInfo(flags.apihost, logger)
-      if (flags.runtimes) {
-        this.displayRuntimes(sysinfo, logger)
-      } else {
-        this.displayLimits(sysinfo, logger)
-      }
+      this.displayLimits(sysinfo, logger)
     } else {
       // We want the version to include a githash.  Versions taken from package.json will have one if they were installed
       // via an update "channel" and these also have the advantage of including a channel name.  However, "stable" versions
@@ -84,7 +82,7 @@ export default class Info extends NimBaseCommand {
   }
 
   // Display the runtimes in a vaguely tabular format
-  async displayRuntimes(_: Record<string, any>, logger: NimLogger): Promise<void> {
+  async displayRuntimes(logger: NimLogger): Promise<void> {
     // Organize the information for display
     const rawDisplay: string[][] = []
     const runtimes = await initRuntimes()
@@ -94,7 +92,10 @@ export default class Info extends NimBaseCommand {
       }
     }
     // Format for display
-    const maxLanguage: number = rawDisplay.reduce((prev, curr) => curr[0].length > prev ? curr[0].length : prev, 0)
+    let maxLanguage: number = rawDisplay.reduce((prev, curr) => curr[0].length > prev ? curr[0].length : prev, 0)
+    if ('Language'.length > maxLanguage) {
+      maxLanguage = 'Language'.length
+    }
     const maxKind = rawDisplay.reduce((prev, curr) => curr[1].length > prev ? curr[1].length : prev, 0)
     const display: string[] = rawDisplay.map(entry => entry[0].padEnd(maxLanguage + 1, ' ') +
       entry[1].padEnd(maxKind + 1, ' ') + entry[2])

--- a/src/commands/project/create.ts
+++ b/src/commands/project/create.ts
@@ -18,15 +18,17 @@ import { createProject, languages } from '../../generator/project'
 
 export default class ProjectCreate extends NimBaseCommand {
   static strict = false
-  static description = `Create a ${branding.brand} Project`
+  static description = `Create a ${branding.brand} Project.
+This command creates a ${branding.brand} project for you to evolve and modify.
+The project begins with some sample code in a chosen programming language.
+For a list of supported languages see '${branding.cmdName}' info --runtimes'.`
 
   static flags = {
     config: flags.boolean({ description: 'Generate template config file (now the default)', hidden: true }),
     language: flags.string({
       char: 'l',
       description: 'Language for the project\'s initial sample',
-      options: languages,
-      default: 'js'
+      default: 'javascript'
     }),
     overwrite: flags.boolean({ char: 'o', description: 'Overwrites the existing file(s)' }),
     ...NimBaseCommand.flags


### PR DESCRIPTION
The main purpose of this PR is eliminate a gotcha when creating a project.   The `nim project create` command was using a fixed list of languages and just assuming that all those languages were supported in the backend by installed runtimes.   This implied invariant happened to be true of the `nimgcp` deployment at the time.

In considering deployments with a smaller (or different) complement of runtimes, this can lead to a developer creating a project which cannot be deployed.    Fixes issue #218.

In adding the check several bugs were discovered that need to be fixed.
1.  In the deployer, the `isValidRuntime` utility was incorrect.   That is fixed in release `3.1.21` of the deployer.
2. In the CLI, the `nim info --runtimes` command was racy (it becomes part of this fix because the developer is referred to it for a list of valid runtimes).  It was not `await`ing the response from the runtimes utilities.   Also, it was interrogating the controller twice and throwing away one of the responses.
3. The output of `nim info --runtimes` was also being formatted incorrectly when no supported language had a name longer than the string "Languages".