### PR TITLE
Make substitution test work regardless of encryption

### DIFF
--- a/tests/multi_substitute/packages/test-multi-substitute/hello.js
+++ b/tests/multi_substitute/packages/test-multi-substitute/hello.js
@@ -1,8 +1,18 @@
 function main(args) {
-    let name = args.name || 'stranger'
-    let greeting = 'Hello ' + name + '!'
-    console.log(greeting)
     return {
-        "greeting": greeting
+        "parameters": [
+            {
+                "key": "A",
+                "value": args.A
+            }, 
+            {
+                "key": "B",
+                "value": args.B
+            },
+            {
+                "key": "C",
+                "value": process.env.C
+            }
+        ]
     }
 }

--- a/tests/multi_substitute/test.bats
+++ b/tests/multi_substitute/test.bats
@@ -13,7 +13,7 @@ teardown_file() {
 }
 
 @test "deploy project with multi-level parameter substitution" {
-	run $NIM action get test-multi-substitute/hello
+	run $NIM action invoke test-multi-substitute/hello -r
 	assert_success
 	assert_output --partial '"parameters": [
     {
@@ -25,9 +25,8 @@ teardown_file() {
       "value": "this is B"
     },
     {
-      "init": true,
       "key": "C",
       "value": "this is C"
     }
-  ],'
+  ]'
 }


### PR DESCRIPTION
As per title. The current test assumes that `action get` returns the parameters in a specific order and with the values in clear text. That won't work in a system with encrypted parameters, so change the test to invoke the action and make it return the values instead.