### PR TITLE
When capturing, all errors should be distinguished

### DIFF
--- a/src/NimBaseCommand.ts
+++ b/src/NimBaseCommand.ts
@@ -123,6 +123,7 @@ export class CaptureLogger implements NimLogger {
   tableColumns: Record<string, unknown> // The column definition needed to format the table with cli-ux
   tableOptions: Record<string, unknown> // The options definition needed to format the table with cli-ux
   captured: string[] = [] // Captured line by line output (flowing via Logger.log)
+  errors: string[] = [] // Captured calls to displayError (these are Errors that are not supposed to be thrown)
   entity: Record<string, unknown> // An output entity if that kind of output was produced
 
   log(msg = '', ...args: any[]): void {
@@ -140,7 +141,7 @@ export class CaptureLogger implements NimLogger {
 
   displayError(msg: string, err?: Error): void {
     msg = improveErrorMsg(msg, err)
-    this.log('Error: %s', msg)
+    this.errors.push(msg)
   }
 
   exit(_code: number): void {


### PR DESCRIPTION
Previously, errors that were not thrown (e.g with 'displayError') would come back in 'captured' and there would be no distinction between them and normal output.   This can undermine some library uses of the CLI where, in the presence of a non-zero exit, it is otherwise unclear what is an error and what is normal.