### PR TITLE
3.0.4 (adopting deployer 4.0.5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@nimbella/nimbella-cli",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nimbella/nimbella-cli",
-      "version": "3.0.3",
+      "version": "3.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/aio-cli-plugin-runtime": "github:nimbella/aio-cli-plugin-runtime#v2021-11-19-1",
         "@adobe/aio-lib-core-config": "^2.0.0",
-        "@nimbella/nimbella-deployer": "4.0.3",
+        "@nimbella/nimbella-deployer": "4.0.5",
         "@nimbella/storage": "^0.0.7",
         "@oclif/command": "^1",
         "@oclif/config": "^1",
@@ -1744,10 +1744,11 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
     },
     "node_modules/@nimbella/nimbella-deployer": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.0.3.tgz",
-      "integrity": "sha512-ZdqbLhpiuBG2VC2nIQWHPEi1btXyuPqRwONIyd09y52dPm2jAFyWeAipUVw9MknImZdkuhkdlTri2Sr+8HzJkQ==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.0.5.tgz",
+      "integrity": "sha512-3UnoCECaLQH1Y+l8KXGoC3t0vrvZ507gXJqaBDxQQHfy3jcT9IFsZXCH/okDbf17Nn4TX4iRN+1DyUApUW+tUA==",
       "dependencies": {
+        "@aws-sdk/client-s3": "^3.27.0",
         "@nimbella/sdk": "^1.3.5",
         "@nimbella/storage": "^0.0.7",
         "@octokit/rest": "^18.7.0",
@@ -11521,10 +11522,11 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
     },
     "@nimbella/nimbella-deployer": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.0.3.tgz",
-      "integrity": "sha512-ZdqbLhpiuBG2VC2nIQWHPEi1btXyuPqRwONIyd09y52dPm2jAFyWeAipUVw9MknImZdkuhkdlTri2Sr+8HzJkQ==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.0.5.tgz",
+      "integrity": "sha512-3UnoCECaLQH1Y+l8KXGoC3t0vrvZ507gXJqaBDxQQHfy3jcT9IFsZXCH/okDbf17Nn4TX4iRN+1DyUApUW+tUA==",
       "requires": {
+        "@aws-sdk/client-s3": "^3.27.0",
         "@nimbella/sdk": "^1.3.5",
         "@nimbella/storage": "^0.0.7",
         "@octokit/rest": "^18.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/nimbella-cli",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "A comprehensive CLI for the Nimbella stack",
   "main": "lib/index.js",
   "repository": {
@@ -16,7 +16,7 @@
   "dependencies": {
     "@adobe/aio-cli-plugin-runtime": "github:nimbella/aio-cli-plugin-runtime#v2021-11-19-1",
     "@adobe/aio-lib-core-config": "^2.0.0",
-    "@nimbella/nimbella-deployer": "4.0.3",
+    "@nimbella/nimbella-deployer": "4.0.5",
     "@nimbella/storage": "^0.0.7",
     "@oclif/command": "^1",
     "@oclif/config": "^1",


### PR DESCRIPTION
This change adopts deployer 4.0.5 (formerly 4.0.3, there was no 4.0.4). 

Changes in the deployer are described in https://github.com/nimbella/nimbella-deployer/releases/tag/v4.0.5.   To summarize:

- go and swift now do remote builds by default when there is no explicit script.   This avoids the under-performing "compile on invoke" behavior when source is provided but no build script.
- the CLI is adjusted to the new remote builder actions available in DigitalOcean clusters.