### PR TITLE
Release v3.0.6 with bug fix for remote build initiated from windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@nimbella/nimbella-cli",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nimbella/nimbella-cli",
-      "version": "3.0.5",
+      "version": "3.0.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/aio-cli-plugin-runtime": "github:nimbella/aio-cli-plugin-runtime#v2021-11-19-1",
         "@adobe/aio-lib-core-config": "^2.0.0",
-        "@nimbella/nimbella-deployer": "4.0.6",
+        "@nimbella/nimbella-deployer": "4.0.7",
         "@nimbella/storage": "^0.0.7",
         "@oclif/command": "^1",
         "@oclif/config": "^1",
@@ -1686,9 +1686,9 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
     },
     "node_modules/@nimbella/nimbella-deployer": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.0.6.tgz",
-      "integrity": "sha512-sWqVZ27l2TnPGLRfI4qI6GUkEP5ET6RngzL26b7AD1ThoTMtZzKrE+3HxffZY2s6rp3dOeTNvByhIbrKMGlLrg==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.0.7.tgz",
+      "integrity": "sha512-Dx5CebuifdsNkkxjKmqvh9HhlCGASJcYuL0dtGuqjCtdkqMReoBifKQdP4hw9wRv7j1Hwou1gGh5TVcfRh0zEw==",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.27.0",
         "@nimbella/sdk": "^1.3.5",
@@ -10798,9 +10798,9 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
     },
     "@nimbella/nimbella-deployer": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.0.6.tgz",
-      "integrity": "sha512-sWqVZ27l2TnPGLRfI4qI6GUkEP5ET6RngzL26b7AD1ThoTMtZzKrE+3HxffZY2s6rp3dOeTNvByhIbrKMGlLrg==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.0.7.tgz",
+      "integrity": "sha512-Dx5CebuifdsNkkxjKmqvh9HhlCGASJcYuL0dtGuqjCtdkqMReoBifKQdP4hw9wRv7j1Hwou1gGh5TVcfRh0zEw==",
       "requires": {
         "@aws-sdk/client-s3": "^3.27.0",
         "@nimbella/sdk": "^1.3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/nimbella-cli",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "A comprehensive CLI for the Nimbella stack",
   "main": "lib/index.js",
   "repository": {
@@ -16,7 +16,7 @@
   "dependencies": {
     "@adobe/aio-cli-plugin-runtime": "github:nimbella/aio-cli-plugin-runtime#v2021-11-19-1",
     "@adobe/aio-lib-core-config": "^2.0.0",
-    "@nimbella/nimbella-deployer": "4.0.6",
+    "@nimbella/nimbella-deployer": "4.0.7",
     "@nimbella/storage": "^0.0.7",
     "@oclif/command": "^1",
     "@oclif/config": "^1",


### PR DESCRIPTION
This PR stages release v3.0.6, which Incorporates deployer 4.0.7.   That, in turn, fixes a bug when a remote build initiated from windows has a `build.sh`.  There was no way previously to mark this as executable and so the build generally failed with a permissions error and exit code 126.