### PR TITLE
Improve branding around output of deploy command

### DIFF
--- a/src/NimBaseCommand.ts
+++ b/src/NimBaseCommand.ts
@@ -56,6 +56,8 @@ export interface Branding {
   workbenchURL: string
   // Preview workbench URL
   previewWorkbenchURL: string
+  // Display header for successful deploys
+  deployedActionsHeader: string
 }
 
 // Branding.  The values here reflect the standard 'nim from Nimbella' branding.
@@ -66,7 +68,8 @@ export let branding: Branding = {
   hostPrefix: 'api',
   namespaceRepair: "Use 'nim logon' to create a new one or 'nim auth switch' to use an existing one",
   workbenchURL: 'https://apigcp.nimbella.io/wb',
-  previewWorkbenchURL: 'https://preview-apigcp.nimbella.io/workbench'
+  previewWorkbenchURL: 'https://preview-apigcp.nimbella.io/workbench',
+  deployedActionsHeader: "Deployed actions ('nim action get <actionName> --url' for URL):"
 }
 
 // A place where workbench can store its help helper

--- a/src/commands/project/deploy.ts
+++ b/src/commands/project/deploy.ts
@@ -184,7 +184,7 @@ function displayHeader(project: string, creds: Credentials, logger: NimLogger) {
     hostClause = `\n  on host '${creds.ow.apihost}'`
   }
   const projectPath = isGithubRef(project) ? project : path.resolve(project)
-  logger.log(`Deploying project '${projectPath}'${namespaceClause}${hostClause}`)
+  logger.log(`Deploying '${projectPath}'${namespaceClause}${hostClause}`)
 }
 
 // Display the result of a successful run when deploying a slice or when JSON is requested.
@@ -255,7 +255,7 @@ function displayResult(result: DeployResponse, watching: boolean, webLocal: stri
       logger.log(`Skipped ${skippedWeb} unchanged web resources${bucketClause}`)
     }
     if (actions.length > 0) {
-      logger.log(`Deployed actions ('${branding.brand} action get <actionName> --url' for URL):`)
+      logger.log(branding.deployedActionsHeader)
       for (const action of actions) {
         logger.log(`  - ${action}`)
       }


### PR DESCRIPTION
This change consists of a small adjustment to the `branding` structure in `NimBaseCommand`.   It now abstracts the header that is shown immediately before the list of successfully deployed projects when using `project deploy`.   It also avoids using the term `project` in the initial header.

The version was incremented to 3.0.7 prior to this change but that release has not been published.   It will be published including this change.