### PR TITLE
Improved debugging for remote build failures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@nimbella/nimbella-cli",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nimbella/nimbella-cli",
-      "version": "3.0.8",
+      "version": "3.0.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/aio-cli-plugin-runtime": "github:nimbella/aio-cli-plugin-runtime#v2021-11-19-1",
         "@adobe/aio-lib-core-config": "^2.0.0",
-        "@nimbella/nimbella-deployer": "4.0.10",
+        "@nimbella/nimbella-deployer": "4.0.11",
         "@nimbella/storage": "^0.0.7",
         "@oclif/command": "^1",
         "@oclif/config": "^1",
@@ -1686,9 +1686,9 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
     },
     "node_modules/@nimbella/nimbella-deployer": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.0.10.tgz",
-      "integrity": "sha512-ThBqSiR359qqCIzo4XqaAU1Fjc2wNx5AaC3PrRPqqUsoyBlyj5rdgoOQNZNrlPPgOcZ0bV2XbScFsSuYTlVs5g==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.0.11.tgz",
+      "integrity": "sha512-kBODz9dPS/YTBXEHxn6RE+0PHntwICHh8QfpXNhPangzBLE+fXe2Pgm0CGrccWPi1ucid8pljrgNTw116qvBMQ==",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.27.0",
         "@nimbella/sdk": "^1.3.5",
@@ -10798,9 +10798,9 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
     },
     "@nimbella/nimbella-deployer": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.0.10.tgz",
-      "integrity": "sha512-ThBqSiR359qqCIzo4XqaAU1Fjc2wNx5AaC3PrRPqqUsoyBlyj5rdgoOQNZNrlPPgOcZ0bV2XbScFsSuYTlVs5g==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.0.11.tgz",
+      "integrity": "sha512-kBODz9dPS/YTBXEHxn6RE+0PHntwICHh8QfpXNhPangzBLE+fXe2Pgm0CGrccWPi1ucid8pljrgNTw116qvBMQ==",
       "requires": {
         "@aws-sdk/client-s3": "^3.27.0",
         "@nimbella/sdk": "^1.3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/nimbella-cli",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "description": "A comprehensive CLI for the Nimbella stack",
   "main": "lib/index.js",
   "repository": {
@@ -16,7 +16,7 @@
   "dependencies": {
     "@adobe/aio-cli-plugin-runtime": "github:nimbella/aio-cli-plugin-runtime#v2021-11-19-1",
     "@adobe/aio-lib-core-config": "^2.0.0",
-    "@nimbella/nimbella-deployer": "4.0.10",
+    "@nimbella/nimbella-deployer": "4.0.11",
     "@nimbella/storage": "^0.0.7",
     "@oclif/command": "^1",
     "@oclif/config": "^1",


### PR DESCRIPTION
Incorporates a deployer change (4.0.11) and increments the nim version (3.0.9) to provide better debugging of remote build failures when `--verbose` is specified.  The error object now contains the complete activation record for builder-related actions that fail once initiated.  Failure to initiate entirely (e.g. 502 errors) are still handled as before.