### PR TITLE
Support multi-line string values in symbolic substitution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@nimbella/nimbella-cli",
-  "version": "3.0.10",
+  "version": "3.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nimbella/nimbella-cli",
-      "version": "3.0.10",
+      "version": "3.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/aio-cli-plugin-runtime": "github:nimbella/aio-cli-plugin-runtime#v2021-11-19-1",
         "@adobe/aio-lib-core-config": "^2.0.0",
-        "@nimbella/nimbella-deployer": "4.0.12",
+        "@nimbella/nimbella-deployer": "4.1.0",
         "@nimbella/storage": "^0.0.7",
         "@oclif/command": "^1",
         "@oclif/config": "^1",
@@ -1686,9 +1686,9 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
     },
     "node_modules/@nimbella/nimbella-deployer": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.0.12.tgz",
-      "integrity": "sha512-MN64pVkhviGqFL18FskTVZHAri6TFRH9flZw0BESDOeVCBJNfQMUGzk0S+uFGJKJsLZ6ehzKShTeFuUJiYQq+A==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.1.0.tgz",
+      "integrity": "sha512-1lSjZBeFIWQJcQLaW2d06pjLhpv/z+mFX2POY+Td9FDLj6MkHaRMeQWCeRhfjJ7LFW3zHwZw5XVo6rwWP+9nSA==",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.27.0",
         "@nimbella/sdk": "^1.3.5",
@@ -10798,9 +10798,9 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
     },
     "@nimbella/nimbella-deployer": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.0.12.tgz",
-      "integrity": "sha512-MN64pVkhviGqFL18FskTVZHAri6TFRH9flZw0BESDOeVCBJNfQMUGzk0S+uFGJKJsLZ6ehzKShTeFuUJiYQq+A==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.1.0.tgz",
+      "integrity": "sha512-1lSjZBeFIWQJcQLaW2d06pjLhpv/z+mFX2POY+Td9FDLj6MkHaRMeQWCeRhfjJ7LFW3zHwZw5XVo6rwWP+9nSA==",
       "requires": {
         "@aws-sdk/client-s3": "^3.27.0",
         "@nimbella/sdk": "^1.3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/nimbella-cli",
-  "version": "3.0.10",
+  "version": "3.1.0",
   "description": "A comprehensive CLI for the Nimbella stack",
   "main": "lib/index.js",
   "repository": {
@@ -16,7 +16,7 @@
   "dependencies": {
     "@adobe/aio-cli-plugin-runtime": "github:nimbella/aio-cli-plugin-runtime#v2021-11-19-1",
     "@adobe/aio-lib-core-config": "^2.0.0",
-    "@nimbella/nimbella-deployer": "4.0.12",
+    "@nimbella/nimbella-deployer": "4.1.0",
     "@nimbella/storage": "^0.0.7",
     "@oclif/command": "^1",
     "@oclif/config": "^1",


### PR DESCRIPTION
Incorporates deployer 4.1.0 and sets CLI version 3.1.0.

This changes allows environment variables or properties in an environment file to have multi-line (newline-separated) values.  At substitution time, these are escaped by default so as to go through the YAML parser as strings.   The escaping can be suppressed using the special syntax `${|SYMBOL}`.   See https://github.com/nimbella/nimbella-deployer/pull/86 for more details.