### PR TITLE
Support multi-line syntax in environment files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@nimbella/nimbella-cli",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nimbella/nimbella-cli",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/aio-cli-plugin-runtime": "github:nimbella/aio-cli-plugin-runtime#v2021-11-19-1",
         "@adobe/aio-lib-core-config": "^2.0.0",
-        "@nimbella/nimbella-deployer": "4.1.0",
+        "@nimbella/nimbella-deployer": "4.1.1",
         "@nimbella/storage": "^0.0.7",
         "@oclif/command": "^1",
         "@oclif/config": "^1",
@@ -1686,9 +1686,9 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
     },
     "node_modules/@nimbella/nimbella-deployer": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.1.0.tgz",
-      "integrity": "sha512-1lSjZBeFIWQJcQLaW2d06pjLhpv/z+mFX2POY+Td9FDLj6MkHaRMeQWCeRhfjJ7LFW3zHwZw5XVo6rwWP+9nSA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.1.1.tgz",
+      "integrity": "sha512-etDFwNRp+Vxd7x78vHXpFu3XLxtDANLOvAnw1MFiAqg6nLOQKqMXZ6qBRO/9WNjnTG3CzhfPMNBrvnWriwJ10Q==",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.27.0",
         "@nimbella/sdk": "^1.3.5",
@@ -1700,7 +1700,7 @@
         "atob": "^2.1.2",
         "axios": "^0.21.4",
         "debug": "^4.1.1",
-        "dotenv": "7.0.0",
+        "dotenv": "^16.0.1",
         "ignore": "5.0.6",
         "js-yaml": "^3.13.1",
         "memory-streams": "^0.1.3",
@@ -1718,11 +1718,11 @@
       }
     },
     "node_modules/@nimbella/nimbella-deployer/node_modules/dotenv": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-7.0.0.tgz",
-      "integrity": "sha512-M3NhsLbV1i6HuGzBUH8vXrtxOk+tWmzWKDMbAVSUp3Zsjm7ywFeuwrUXhmhQyRK1q5B5GGy7hcXPbj3bnfZg2g==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
+      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
       "engines": {
-        "node": ">=6"
+        "node": ">=12"
       }
     },
     "node_modules/@nimbella/sdk": {
@@ -10798,9 +10798,9 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
     },
     "@nimbella/nimbella-deployer": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.1.0.tgz",
-      "integrity": "sha512-1lSjZBeFIWQJcQLaW2d06pjLhpv/z+mFX2POY+Td9FDLj6MkHaRMeQWCeRhfjJ7LFW3zHwZw5XVo6rwWP+9nSA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.1.1.tgz",
+      "integrity": "sha512-etDFwNRp+Vxd7x78vHXpFu3XLxtDANLOvAnw1MFiAqg6nLOQKqMXZ6qBRO/9WNjnTG3CzhfPMNBrvnWriwJ10Q==",
       "requires": {
         "@aws-sdk/client-s3": "^3.27.0",
         "@nimbella/sdk": "^1.3.5",
@@ -10812,7 +10812,7 @@
         "atob": "^2.1.2",
         "axios": "^0.21.4",
         "debug": "^4.1.1",
-        "dotenv": "7.0.0",
+        "dotenv": "^16.0.1",
         "ignore": "5.0.6",
         "js-yaml": "^3.13.1",
         "memory-streams": "^0.1.3",
@@ -10827,9 +10827,9 @@
       },
       "dependencies": {
         "dotenv": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-7.0.0.tgz",
-          "integrity": "sha512-M3NhsLbV1i6HuGzBUH8vXrtxOk+tWmzWKDMbAVSUp3Zsjm7ywFeuwrUXhmhQyRK1q5B5GGy7hcXPbj3bnfZg2g=="
+          "version": "16.0.1",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
+          "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/nimbella-cli",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "A comprehensive CLI for the Nimbella stack",
   "main": "lib/index.js",
   "repository": {
@@ -16,7 +16,7 @@
   "dependencies": {
     "@adobe/aio-cli-plugin-runtime": "github:nimbella/aio-cli-plugin-runtime#v2021-11-19-1",
     "@adobe/aio-lib-core-config": "^2.0.0",
-    "@nimbella/nimbella-deployer": "4.1.0",
+    "@nimbella/nimbella-deployer": "4.1.1",
     "@nimbella/storage": "^0.0.7",
     "@oclif/command": "^1",
     "@oclif/config": "^1",


### PR DESCRIPTION
Because the Nimbella deployer had locked down version 7.0.0 of the `dotenv` parser, its environment files don't support the latest multi-line syntax recommendations of `dotenv`.   This PR incorporates deployer 4.1.1 and declares CLI 3.1.1 to pick up the change to fix this.   The latest `dotenv` should now be used.