### PR TITLE
Use .deployed, not .nimbella, for status directory

### DIFF
--- a/src/generator/project.ts
+++ b/src/generator/project.ts
@@ -24,6 +24,7 @@ import { branding } from '../NimBaseCommand'
 // It is considered best practice for developers to list these in a personal global
 // ignore file (`core.excludesfile` in the git config) and not in a committed .gitignore.
 const gitignores = `.nimbella
+.deployed
 __deployer__.zip
 __pycache__/
 node_modules


### PR DESCRIPTION
When generating a new project using `nim project create` the `.gitignore` file that is generated now includes `.deployed` as well as `.nimbella`.   This is the new name that the deployer will be using for the deployer-generated status directory of a project.   I chose not to remove `.nimbella` altogether since a developer with a mixture of old and new projects may end up copying or cutting and pasting `.gitignore` files.