### PR TITLE
Use 'functions' not 'actions' in project.yml and use .deployed instead of .nimbella

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@nimbella/nimbella-cli",
-  "version": "3.1.1",
+  "version": "4.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nimbella/nimbella-cli",
-      "version": "3.1.1",
+      "version": "4.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/aio-cli-plugin-runtime": "github:nimbella/aio-cli-plugin-runtime#v2021-11-19-1",
         "@adobe/aio-lib-core-config": "^2.0.0",
-        "@nimbella/nimbella-deployer": "4.1.1",
+        "@nimbella/nimbella-deployer": "4.2.0",
         "@nimbella/storage": "^0.0.7",
         "@oclif/command": "^1",
         "@oclif/config": "^1",
@@ -347,16 +347,16 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.95.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.95.0.tgz",
-      "integrity": "sha512-IyPmgh5h8X5810buIcW0EqYZdm+MUN8FFugGQnpPFofhV77q9ISVS0XdsieZjBpZrFNg6qoSyvytwkGGGZP1IQ==",
+      "version": "3.100.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.100.0.tgz",
+      "integrity": "sha512-UmgFdJabWtiUS4dWsC3kZ+ZMvH5QUUbDnLS8pT12duwLGt+xlWPn3PUkV8kL6qjG6XePLUgCqFTLjDD4tsTZNg==",
       "dependencies": {
         "@aws-crypto/sha1-browser": "2.0.0",
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.95.0",
+        "@aws-sdk/client-sts": "3.100.0",
         "@aws-sdk/config-resolver": "3.80.0",
-        "@aws-sdk/credential-provider-node": "3.95.0",
+        "@aws-sdk/credential-provider-node": "3.100.0",
         "@aws-sdk/eventstream-serde-browser": "3.78.0",
         "@aws-sdk/eventstream-serde-config-resolver": "3.78.0",
         "@aws-sdk/eventstream-serde-node": "3.78.0",
@@ -384,15 +384,15 @@
         "@aws-sdk/node-http-handler": "3.94.0",
         "@aws-sdk/protocol-http": "3.78.0",
         "@aws-sdk/signature-v4-multi-region": "3.88.0",
-        "@aws-sdk/smithy-client": "3.85.0",
+        "@aws-sdk/smithy-client": "3.99.0",
         "@aws-sdk/types": "3.78.0",
         "@aws-sdk/url-parser": "3.78.0",
         "@aws-sdk/util-base64-browser": "3.58.0",
         "@aws-sdk/util-base64-node": "3.55.0",
         "@aws-sdk/util-body-length-browser": "3.55.0",
         "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.85.0",
-        "@aws-sdk/util-defaults-mode-node": "3.85.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.99.0",
+        "@aws-sdk/util-defaults-mode-node": "3.99.0",
         "@aws-sdk/util-stream-browser": "3.78.0",
         "@aws-sdk/util-stream-node": "3.78.0",
         "@aws-sdk/util-user-agent-browser": "3.78.0",
@@ -410,9 +410,9 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.95.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.95.0.tgz",
-      "integrity": "sha512-yxiVyRG5ULTVzOTmlrsy1krjpBQo20+ZfQ9p++A7cA8dIsytzjlPLvtY+Pzz0pTa3h2B6tlVBmumgEQzh5Y8Ug==",
+      "version": "3.100.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.100.0.tgz",
+      "integrity": "sha512-nmBRUO5QfQ2IO8fHb37p8HT3n1ZooPb3sfTQejrpFH9Eq82VEOatIGt6yH3yTQ8+mhbabEhV5aY2wt/0D7wGVA==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -430,15 +430,15 @@
         "@aws-sdk/node-config-provider": "3.80.0",
         "@aws-sdk/node-http-handler": "3.94.0",
         "@aws-sdk/protocol-http": "3.78.0",
-        "@aws-sdk/smithy-client": "3.85.0",
+        "@aws-sdk/smithy-client": "3.99.0",
         "@aws-sdk/types": "3.78.0",
         "@aws-sdk/url-parser": "3.78.0",
         "@aws-sdk/util-base64-browser": "3.58.0",
         "@aws-sdk/util-base64-node": "3.55.0",
         "@aws-sdk/util-body-length-browser": "3.55.0",
         "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.85.0",
-        "@aws-sdk/util-defaults-mode-node": "3.85.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.99.0",
+        "@aws-sdk/util-defaults-mode-node": "3.99.0",
         "@aws-sdk/util-user-agent-browser": "3.78.0",
         "@aws-sdk/util-user-agent-node": "3.80.0",
         "@aws-sdk/util-utf8-browser": "3.55.0",
@@ -450,14 +450,14 @@
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.95.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.95.0.tgz",
-      "integrity": "sha512-qeoiEyBB5IQyjgjkCCBiQnISar7OJgjuTf2alM6ehjq8H4/T5VeMCeohEs5FR0/O60sJn40ZpL3YY/OmMh55UA==",
+      "version": "3.100.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.100.0.tgz",
+      "integrity": "sha512-WHy0e6COf6/LfMsYqG9H4SGaQRDjuckMtwOLtu6cYr4cro3bOU5pNuyEjAdUHCpuhZgiE6gkZozhTlxMJqIuRQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
         "@aws-sdk/config-resolver": "3.80.0",
-        "@aws-sdk/credential-provider-node": "3.95.0",
+        "@aws-sdk/credential-provider-node": "3.100.0",
         "@aws-sdk/fetch-http-handler": "3.78.0",
         "@aws-sdk/hash-node": "3.78.0",
         "@aws-sdk/invalid-dependency": "3.78.0",
@@ -473,15 +473,15 @@
         "@aws-sdk/node-config-provider": "3.80.0",
         "@aws-sdk/node-http-handler": "3.94.0",
         "@aws-sdk/protocol-http": "3.78.0",
-        "@aws-sdk/smithy-client": "3.85.0",
+        "@aws-sdk/smithy-client": "3.99.0",
         "@aws-sdk/types": "3.78.0",
         "@aws-sdk/url-parser": "3.78.0",
         "@aws-sdk/util-base64-browser": "3.58.0",
         "@aws-sdk/util-base64-node": "3.55.0",
         "@aws-sdk/util-body-length-browser": "3.55.0",
         "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.85.0",
-        "@aws-sdk/util-defaults-mode-node": "3.85.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.99.0",
+        "@aws-sdk/util-defaults-mode-node": "3.99.0",
         "@aws-sdk/util-user-agent-browser": "3.78.0",
         "@aws-sdk/util-user-agent-node": "3.80.0",
         "@aws-sdk/util-utf8-browser": "3.55.0",
@@ -538,13 +538,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.95.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.95.0.tgz",
-      "integrity": "sha512-Ditfnmo8/F79Zj8HmaRZZTDsthhvKcdgGFus+pF3kxZxyR3YU/k7/eGUISZeCQhA0/9nwxXMFDUmAIsa0AMfyg==",
+      "version": "3.100.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.100.0.tgz",
+      "integrity": "sha512-2pCtth/Iv4mATRwb2g1nJdd9TolMyhTnhcskopukFvzp13VS5cgtz0hgYmJNnztTF8lpKJhJaidtKS5JJTWnHg==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.78.0",
         "@aws-sdk/credential-provider-imds": "3.81.0",
-        "@aws-sdk/credential-provider-sso": "3.95.0",
+        "@aws-sdk/credential-provider-sso": "3.100.0",
         "@aws-sdk/credential-provider-web-identity": "3.78.0",
         "@aws-sdk/property-provider": "3.78.0",
         "@aws-sdk/shared-ini-file-loader": "3.80.0",
@@ -556,15 +556,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.95.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.95.0.tgz",
-      "integrity": "sha512-NCXejOQg5p+oJPaUPa+jIrU7pStm8zZtOn6lXVnubZrQClv2+ZQrgxVt6otN464SWqMQbmLFYNyYf4bsLJaEhA==",
+      "version": "3.100.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.100.0.tgz",
+      "integrity": "sha512-PMIPnn/dhv9tlWR0qXnANJpTumujWfhKnLAsV3BUqB1K9IzWqz/zXjCT0jcSUTY8X/VkSuehtBdCKvOOM5mMqg==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.78.0",
         "@aws-sdk/credential-provider-imds": "3.81.0",
-        "@aws-sdk/credential-provider-ini": "3.95.0",
+        "@aws-sdk/credential-provider-ini": "3.100.0",
         "@aws-sdk/credential-provider-process": "3.80.0",
-        "@aws-sdk/credential-provider-sso": "3.95.0",
+        "@aws-sdk/credential-provider-sso": "3.100.0",
         "@aws-sdk/credential-provider-web-identity": "3.78.0",
         "@aws-sdk/property-provider": "3.78.0",
         "@aws-sdk/shared-ini-file-loader": "3.80.0",
@@ -590,11 +590,11 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.95.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.95.0.tgz",
-      "integrity": "sha512-YIzBBWUKkazvoM8CsCbf4YIs5ENtOr5KXUd6e993c3oRMNsUykOtf/AUBN6G3HItuyxoA8vW/8M6tKX44cRCAg==",
+      "version": "3.100.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.100.0.tgz",
+      "integrity": "sha512-DwJvrh77vBJ1/fS9z0i2QuIvSk4pATA4DH8AEWoQ8LQX97tp3es7gZV5Wu93wFsEyIYC8penz6pNVq5QajMk2A==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.95.0",
+        "@aws-sdk/client-sso": "3.100.0",
         "@aws-sdk/property-provider": "3.78.0",
         "@aws-sdk/shared-ini-file-loader": "3.80.0",
         "@aws-sdk/types": "3.78.0",
@@ -1056,16 +1056,16 @@
       }
     },
     "node_modules/@aws-sdk/s3-request-presigner": {
-      "version": "3.95.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.95.0.tgz",
-      "integrity": "sha512-mZPE/AAHcXAnIR41AV7FeKj2YPclYPp0vccrYQW/pQHgyMSVXcQQm52XnG2FwIjAK+BH4/fgCqYXevc7kOpi+g==",
+      "version": "3.100.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.100.0.tgz",
+      "integrity": "sha512-32j9o2ChP2pzsua5+Ci9XFKBsFXxlE5muVD9CSpEG9UfUieORAvXsZVChu86IWBFR2nQRm0vebrwJC2tKsgu1A==",
       "dependencies": {
         "@aws-sdk/middleware-sdk-s3": "3.86.0",
         "@aws-sdk/protocol-http": "3.78.0",
         "@aws-sdk/signature-v4-multi-region": "3.88.0",
-        "@aws-sdk/smithy-client": "3.85.0",
+        "@aws-sdk/smithy-client": "3.99.0",
         "@aws-sdk/types": "3.78.0",
-        "@aws-sdk/util-create-request": "3.85.0",
+        "@aws-sdk/util-create-request": "3.99.0",
         "@aws-sdk/util-format-url": "3.78.0",
         "tslib": "^2.3.1"
       },
@@ -1132,9 +1132,9 @@
       }
     },
     "node_modules/@aws-sdk/smithy-client": {
-      "version": "3.85.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.85.0.tgz",
-      "integrity": "sha512-Ox/yQEAnANzhpJMyrpuxWtF/i3EviavENczT7fo4uwSyZTz/sfSBQNjs/YAG1UeA6uOI3pBP5EaFERV5hr2fRA==",
+      "version": "3.99.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.99.0.tgz",
+      "integrity": "sha512-N9xgCcwbOBZ4/WuROzlErExXV6+vFrFkNJzeBT31/avvrHXjxgxwQlMoXoQCfM8PyRuDuVSfZeoh1iIRfoxidA==",
       "dependencies": {
         "@aws-sdk/middleware-stack": "3.78.0",
         "@aws-sdk/types": "3.78.0",
@@ -1236,12 +1236,12 @@
       }
     },
     "node_modules/@aws-sdk/util-create-request": {
-      "version": "3.85.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-create-request/-/util-create-request-3.85.0.tgz",
-      "integrity": "sha512-AQrG+mIgjtcN23O4zCAWpIwyPIHzKZAcPbF8OROAbNcQcMwyg2Q9hyodRR5l3fzGG2jiRt9P3copvORBWB7diA==",
+      "version": "3.99.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-create-request/-/util-create-request-3.99.0.tgz",
+      "integrity": "sha512-7+jM8xe2u5FW7ufRqHTmvJa7nH9f8uZXuWpHcmITKm8IRnkst1ib1DUctEZE+go9lnonzy4TttSNMt5NqFCgOA==",
       "dependencies": {
         "@aws-sdk/middleware-stack": "3.78.0",
-        "@aws-sdk/smithy-client": "3.85.0",
+        "@aws-sdk/smithy-client": "3.99.0",
         "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       },
@@ -1250,9 +1250,9 @@
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.85.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.85.0.tgz",
-      "integrity": "sha512-oqK/e2pHuMWrvTJWtDBzylbj232ezlTay5dCq4RQlyi3LPPVBQ08haYD1Mk2ikQ/qa0XvbSD6YVhjpTlvwRNjw==",
+      "version": "3.99.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.99.0.tgz",
+      "integrity": "sha512-qSYjUGuN8n7Q/zAi0tzU4BrU389jQosXtjp7eHpLATl0pKGpaHx6rJNwbiNhvBhBEfmSgqsJ09b4gZUpUezHEw==",
       "dependencies": {
         "@aws-sdk/property-provider": "3.78.0",
         "@aws-sdk/types": "3.78.0",
@@ -1264,9 +1264,9 @@
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.85.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.85.0.tgz",
-      "integrity": "sha512-KDNl4H8jJJLh6y7I3MSwRKe4plKbFKK8MVkS0+Fce/GJh4EnqxF0HzMMaSeNUcPvO2wHRq2a60+XW+0d7eWo1A==",
+      "version": "3.99.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.99.0.tgz",
+      "integrity": "sha512-8TUO0kEnQcgT1gAW9y9oO6a5gKhfEGEUeKidEgbTczEUrjr3aCXIC+p0DI5FJfImwPrTKXra8A22utDM92phWw==",
       "dependencies": {
         "@aws-sdk/config-resolver": "3.80.0",
         "@aws-sdk/credential-provider-imds": "3.81.0",
@@ -1494,13 +1494,13 @@
     "node_modules/@babel/highlight/node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
     },
     "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
@@ -1686,9 +1686,9 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
     },
     "node_modules/@nimbella/nimbella-deployer": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.1.1.tgz",
-      "integrity": "sha512-etDFwNRp+Vxd7x78vHXpFu3XLxtDANLOvAnw1MFiAqg6nLOQKqMXZ6qBRO/9WNjnTG3CzhfPMNBrvnWriwJ10Q==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.2.0.tgz",
+      "integrity": "sha512-Q4G5VKpqJG4nwLBn4iUgiGoiKMuld0f7pX91YaKjkCl049w/B0u8XF6+PlfLSMgSicNLLplRzLkzO5gbONoyZg==",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.27.0",
         "@nimbella/sdk": "^1.3.5",
@@ -2095,7 +2095,7 @@
     "node_modules/@oclif/plugin-help/node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "node_modules/@oclif/plugin-help/node_modules/emoji-regex": {
       "version": "7.0.3",
@@ -2105,7 +2105,7 @@
     "node_modules/@oclif/plugin-help/node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "engines": {
         "node": ">=0.8.0"
       }
@@ -3003,13 +3003,13 @@
     "node_modules/args/node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
     },
     "node_modules/args/node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
@@ -3368,9 +3368,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001342",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001342.tgz",
-      "integrity": "sha512-bn6sOCu7L7jcbBbyNhLg0qzXdJ/PMbybZTH/BA6Roet9wxYRm6Tr9D0s0uhLkOZ6MSG+QU6txUgdpr3MXIVqjA==",
+      "version": "1.0.30001344",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001344.tgz",
+      "integrity": "sha512-0ZFjnlCaXNOAYcV7i+TtdKBp0L/3XEU2MF/x6Du1lrh+SRX4IfzIVL4HNJg5pB2PmFb8rszIGyOvsZnqqRoc2g==",
       "funding": [
         {
           "type": "opencollective",
@@ -3651,7 +3651,7 @@
     "node_modules/color/node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "node_modules/colorspace": {
       "version": "1.1.4",
@@ -3695,7 +3695,7 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "node_modules/configstore": {
       "version": "5.0.1",
@@ -3766,7 +3766,7 @@
     "node_modules/crypt": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
       "engines": {
         "node": "*"
       }
@@ -3851,7 +3851,7 @@
     "node_modules/detect-file": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
-      "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
+      "integrity": "sha512-DtCOLG98P007x7wiiOmfI0fi3eIKyWiLTGJ2MDnVi/E04lWGbf+JzrRHMm0rgIIZJGtHpKpbVgLWHrv8xXpc3Q==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3928,9 +3928,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.137",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz",
-      "integrity": "sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA=="
+      "version": "1.4.141",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.141.tgz",
+      "integrity": "sha512-mfBcbqc0qc6RlxrsIgLG2wCqkiPAjEezHxGTu7p3dHHFOurH4EjS9rFZndX5axC8264rI1Pcbw8uQP39oZckeA=="
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -3977,7 +3977,7 @@
     "node_modules/ent": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
-      "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0="
+      "integrity": "sha512-GHrMyVZQWvTIdDtpiEXdHZnFQKzeO09apj8Cbl4pKWy4i0Oprcq17usfDt5aO63swf0JOeMWjWQE/LzgSRuWpA=="
     },
     "node_modules/entities": {
       "version": "2.2.0",
@@ -4072,15 +4072,15 @@
     "node_modules/es6-promisify": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
       "dependencies": {
         "es6-promise": "^4.0.3"
       }
     },
     "node_modules/esbuild": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.39.tgz",
-      "integrity": "sha512-2kKujuzvRWYtwvNjYDY444LQIA3TyJhJIX3Yo4+qkFlDDtGlSicWgeHVJqMUP/2sSfH10PGwfsj+O2ro1m10xQ==",
+      "version": "0.14.41",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.41.tgz",
+      "integrity": "sha512-uZl2CH5nwayLPi1Unhfk+vBBjD3FDlYQ+v24qAlj2oZMYQP8pFs1k3DK5ViD+keF3JnuV4K7JtqVvBmTDwVEbA==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -4090,32 +4090,32 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "esbuild-android-64": "0.14.39",
-        "esbuild-android-arm64": "0.14.39",
-        "esbuild-darwin-64": "0.14.39",
-        "esbuild-darwin-arm64": "0.14.39",
-        "esbuild-freebsd-64": "0.14.39",
-        "esbuild-freebsd-arm64": "0.14.39",
-        "esbuild-linux-32": "0.14.39",
-        "esbuild-linux-64": "0.14.39",
-        "esbuild-linux-arm": "0.14.39",
-        "esbuild-linux-arm64": "0.14.39",
-        "esbuild-linux-mips64le": "0.14.39",
-        "esbuild-linux-ppc64le": "0.14.39",
-        "esbuild-linux-riscv64": "0.14.39",
-        "esbuild-linux-s390x": "0.14.39",
-        "esbuild-netbsd-64": "0.14.39",
-        "esbuild-openbsd-64": "0.14.39",
-        "esbuild-sunos-64": "0.14.39",
-        "esbuild-windows-32": "0.14.39",
-        "esbuild-windows-64": "0.14.39",
-        "esbuild-windows-arm64": "0.14.39"
+        "esbuild-android-64": "0.14.41",
+        "esbuild-android-arm64": "0.14.41",
+        "esbuild-darwin-64": "0.14.41",
+        "esbuild-darwin-arm64": "0.14.41",
+        "esbuild-freebsd-64": "0.14.41",
+        "esbuild-freebsd-arm64": "0.14.41",
+        "esbuild-linux-32": "0.14.41",
+        "esbuild-linux-64": "0.14.41",
+        "esbuild-linux-arm": "0.14.41",
+        "esbuild-linux-arm64": "0.14.41",
+        "esbuild-linux-mips64le": "0.14.41",
+        "esbuild-linux-ppc64le": "0.14.41",
+        "esbuild-linux-riscv64": "0.14.41",
+        "esbuild-linux-s390x": "0.14.41",
+        "esbuild-netbsd-64": "0.14.41",
+        "esbuild-openbsd-64": "0.14.41",
+        "esbuild-sunos-64": "0.14.41",
+        "esbuild-windows-32": "0.14.41",
+        "esbuild-windows-64": "0.14.41",
+        "esbuild-windows-arm64": "0.14.41"
       }
     },
     "node_modules/esbuild-android-64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.39.tgz",
-      "integrity": "sha512-EJOu04p9WgZk0UoKTqLId9VnIsotmI/Z98EXrKURGb3LPNunkeffqQIkjS2cAvidh+OK5uVrXaIP229zK6GvhQ==",
+      "version": "0.14.41",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.41.tgz",
+      "integrity": "sha512-byyo8LPOGHzAqxbwh2Q72d7L+rXXTsr/KALjsiCySrJ60CGMe80i3bwoQ+WODxsGaH08R//yg5oc7xHKgQz4uw==",
       "cpu": [
         "x64"
       ],
@@ -4129,9 +4129,9 @@
       }
     },
     "node_modules/esbuild-android-arm64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.39.tgz",
-      "integrity": "sha512-+twajJqO7n3MrCz9e+2lVOnFplRsaGRwsq1KL/uOy7xK7QdRSprRQcObGDeDZUZsacD5gUkk6OiHiYp6RzU3CA==",
+      "version": "0.14.41",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.41.tgz",
+      "integrity": "sha512-7koo9Dm/mwK4M8PGQX8JQRc4UQ4Wj7DT1nD4BQkVs2jxtHbYOlnsQH0fneKSXZVmnBIHYcntr/e1VU5gnYLvGQ==",
       "cpu": [
         "arm64"
       ],
@@ -4145,9 +4145,9 @@
       }
     },
     "node_modules/esbuild-darwin-64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.39.tgz",
-      "integrity": "sha512-ImT6eUw3kcGcHoUxEcdBpi6LfTRWaV6+qf32iYYAfwOeV+XaQ/Xp5XQIBiijLeo+LpGci9M0FVec09nUw41a5g==",
+      "version": "0.14.41",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.41.tgz",
+      "integrity": "sha512-kW8fC2auh9jjmBXudTmlMfbBCMYMuujhxG40CxMhKiQ8NLBK4RU9yUYY6ss7QJp24kVTtKd4IvfwOio9SE53MA==",
       "cpu": [
         "x64"
       ],
@@ -4161,9 +4161,9 @@
       }
     },
     "node_modules/esbuild-darwin-arm64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.39.tgz",
-      "integrity": "sha512-/fcQ5UhE05OiT+bW5v7/up1bDsnvaRZPJxXwzXsMRrr7rZqPa85vayrD723oWMT64dhrgWeA3FIneF8yER0XTw==",
+      "version": "0.14.41",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.41.tgz",
+      "integrity": "sha512-cO0EPkiQt0bERH9sZFIoTywWfGhEpshdpvQpDfLh/ZJLeioQfaarM9YDrmID+f7k77djh0mdyfsC6XpS0HlLsw==",
       "cpu": [
         "arm64"
       ],
@@ -4177,9 +4177,9 @@
       }
     },
     "node_modules/esbuild-freebsd-64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.39.tgz",
-      "integrity": "sha512-oMNH8lJI4wtgN5oxuFP7BQ22vgB/e3Tl5Woehcd6i2r6F3TszpCnNl8wo2d/KvyQ4zvLvCWAlRciumhQg88+kQ==",
+      "version": "0.14.41",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.41.tgz",
+      "integrity": "sha512-6tsMDK6b7czCOjsr68BgVogFXcTCWL3T7yFXRFuAmXwY9ybYgX8sybD7ztrRB03dLAPeMxHo+PzeMD6LdVrLdQ==",
       "cpu": [
         "x64"
       ],
@@ -4193,9 +4193,9 @@
       }
     },
     "node_modules/esbuild-freebsd-arm64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.39.tgz",
-      "integrity": "sha512-1GHK7kwk57ukY2yI4ILWKJXaxfr+8HcM/r/JKCGCPziIVlL+Wi7RbJ2OzMcTKZ1HpvEqCTBT/J6cO4ZEwW4Ypg==",
+      "version": "0.14.41",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.41.tgz",
+      "integrity": "sha512-AQ2S/VCLKVBe/+HNiFLyp3w9i7AEtCOWEzKHSkfHk0VO5bPzHd7WJfWmj1Bxliu7vdPESbiDUTJIH3rDt4bzSA==",
       "cpu": [
         "arm64"
       ],
@@ -4209,9 +4209,9 @@
       }
     },
     "node_modules/esbuild-linux-32": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.39.tgz",
-      "integrity": "sha512-g97Sbb6g4zfRLIxHgW2pc393DjnkTRMeq3N1rmjDUABxpx8SjocK4jLen+/mq55G46eE2TA0MkJ4R3SpKMu7dg==",
+      "version": "0.14.41",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.41.tgz",
+      "integrity": "sha512-sb7Kah5Px6BNZ6gzm0nJLuDeAJKbIlaKIoI9zgZ5dFDxZSn91TMAHJz5W39YDJ8+ZaGJYIdqZSpDo+4G769mZw==",
       "cpu": [
         "ia32"
       ],
@@ -4225,9 +4225,9 @@
       }
     },
     "node_modules/esbuild-linux-64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.39.tgz",
-      "integrity": "sha512-4tcgFDYWdI+UbNMGlua9u1Zhu0N5R6u9tl5WOM8aVnNX143JZoBZLpCuUr5lCKhnD0SCO+5gUyMfupGrHtfggQ==",
+      "version": "0.14.41",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.41.tgz",
+      "integrity": "sha512-PeI0bfbv+5ondZRhPRszptp3RQRRAPxpOB2CYDphKske5+UlCXPi4Af+T++OqhV5TEpymTfxJdJQ1sn1w32coA==",
       "cpu": [
         "x64"
       ],
@@ -4241,9 +4241,9 @@
       }
     },
     "node_modules/esbuild-linux-arm": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.39.tgz",
-      "integrity": "sha512-t0Hn1kWVx5UpCzAJkKRfHeYOLyFnXwYynIkK54/h3tbMweGI7dj400D1k0Vvtj2u1P+JTRT9tx3AjtLEMmfVBQ==",
+      "version": "0.14.41",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.41.tgz",
+      "integrity": "sha512-8DQ6Sv3XNwgu0cnPA3q+kJSqfOYLDqWzpW8dPF+/Or23bS/5EIT/CzN73uIhR8A3AokXIczn88VKti7Xtv+V2g==",
       "cpu": [
         "arm"
       ],
@@ -4257,9 +4257,9 @@
       }
     },
     "node_modules/esbuild-linux-arm64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.39.tgz",
-      "integrity": "sha512-23pc8MlD2D6Px1mV8GMglZlKgwgNKAO8gsgsLLcXWSs9lQsCYkIlMo/2Ycfo5JrDIbLdwgP8D2vpfH2KcBqrDQ==",
+      "version": "0.14.41",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.41.tgz",
+      "integrity": "sha512-aAhBX6kVG8hTVuANE90ORobioHdpZLzy8Fibf4XBuG4IuJfjgM5N4wFIq2Tpd+Ykit432PL/YOQhZ4W6nVc4cQ==",
       "cpu": [
         "arm64"
       ],
@@ -4273,9 +4273,9 @@
       }
     },
     "node_modules/esbuild-linux-mips64le": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.39.tgz",
-      "integrity": "sha512-epwlYgVdbmkuRr5n4es3B+yDI0I2e/nxhKejT9H0OLxFAlMkeQZxSpxATpDc9m8NqRci6Kwyb/SfmD1koG2Zuw==",
+      "version": "0.14.41",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.41.tgz",
+      "integrity": "sha512-88xo4FRYQ2laMJnrqZu8j5q531XT/odZnhO5NLWO/NdweIdT8F+QL0fNIBIf+nVkC1d0Psgmt+g35GAODMDl8g==",
       "cpu": [
         "mips64el"
       ],
@@ -4289,9 +4289,9 @@
       }
     },
     "node_modules/esbuild-linux-ppc64le": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.39.tgz",
-      "integrity": "sha512-W/5ezaq+rQiQBThIjLMNjsuhPHg+ApVAdTz2LvcuesZFMsJoQAW2hutoyg47XxpWi7aEjJGrkS26qCJKhRn3QQ==",
+      "version": "0.14.41",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.41.tgz",
+      "integrity": "sha512-kJ0r/Cg3LzFzHhbBsvqi/hDPGKMGzFiPGOmUvqTkfVXhRUQtOMkXkyKdP7OEMRb8ctPtnptsZOOXPHRdU0NdJQ==",
       "cpu": [
         "ppc64"
       ],
@@ -4305,9 +4305,9 @@
       }
     },
     "node_modules/esbuild-linux-riscv64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.39.tgz",
-      "integrity": "sha512-IS48xeokcCTKeQIOke2O0t9t14HPvwnZcy+5baG13Z1wxs9ZrC5ig5ypEQQh4QMKxURD5TpCLHw2W42CLuVZaA==",
+      "version": "0.14.41",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.41.tgz",
+      "integrity": "sha512-ZJ7d/qFRx14J3aP75ccrFSZyuYZ1hu8IVfwVqyQg4jQFgNME2FMz7pZMskBJ0fSW8QcYUnN3RubFXWijyjKUug==",
       "cpu": [
         "riscv64"
       ],
@@ -4321,9 +4321,9 @@
       }
     },
     "node_modules/esbuild-linux-s390x": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.39.tgz",
-      "integrity": "sha512-zEfunpqR8sMomqXhNTFEKDs+ik7HC01m3M60MsEjZOqaywHu5e5682fMsqOlZbesEAAaO9aAtRBsU7CHnSZWyA==",
+      "version": "0.14.41",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.41.tgz",
+      "integrity": "sha512-xeWAEZt1jAfYkYuyIUuHKpH/oj7O862Je5HTH9E+4sEfoOnZaAmFrisbXjGDKXjMRKYscFlM8wXdNBmiqQlT8g==",
       "cpu": [
         "s390x"
       ],
@@ -4337,9 +4337,9 @@
       }
     },
     "node_modules/esbuild-netbsd-64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.39.tgz",
-      "integrity": "sha512-Uo2suJBSIlrZCe4E0k75VDIFJWfZy+bOV6ih3T4MVMRJh1lHJ2UyGoaX4bOxomYN3t+IakHPyEoln1+qJ1qYaA==",
+      "version": "0.14.41",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.41.tgz",
+      "integrity": "sha512-X/UE3Asqy594/atYi/STgYtaMQBJwtZKF0KFFdJTkwb6rtaoHCM1o482iHibgnSK7CicuRhyTZ+cNx4OFqRQAg==",
       "cpu": [
         "x64"
       ],
@@ -4372,9 +4372,9 @@
       "dev": true
     },
     "node_modules/esbuild-openbsd-64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.39.tgz",
-      "integrity": "sha512-secQU+EpgUPpYjJe3OecoeGKVvRMLeKUxSMGHnK+aK5uQM3n1FPXNJzyz1LHFOo0WOyw+uoCxBYdM4O10oaCAA==",
+      "version": "0.14.41",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.41.tgz",
+      "integrity": "sha512-6m+1dtdO+4KaU3R0UTT82hxWxWpFCjgSHhQl/PKtMmq+CvvxRQDcTwujLC843M7ChGVWNM2q1s6YCwoA0WQ9kw==",
       "cpu": [
         "x64"
       ],
@@ -4388,9 +4388,9 @@
       }
     },
     "node_modules/esbuild-sunos-64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.39.tgz",
-      "integrity": "sha512-qHq0t5gePEDm2nqZLb+35p/qkaXVS7oIe32R0ECh2HOdiXXkj/1uQI9IRogGqKkK+QjDG+DhwiUw7QoHur/Rwg==",
+      "version": "0.14.41",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.41.tgz",
+      "integrity": "sha512-p96tTTcE8/WY7A4Udh+fxVUTGL8rIXOpyxyhZiXug+f7DGbjE24PbewqgIBRSDyM7xRUty+1RzqyJz73YIV6yg==",
       "cpu": [
         "x64"
       ],
@@ -4404,9 +4404,9 @@
       }
     },
     "node_modules/esbuild-windows-32": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.39.tgz",
-      "integrity": "sha512-XPjwp2OgtEX0JnOlTgT6E5txbRp6Uw54Isorm3CwOtloJazeIWXuiwK0ONJBVb/CGbiCpS7iP2UahGgd2p1x+Q==",
+      "version": "0.14.41",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.41.tgz",
+      "integrity": "sha512-jS+/pGyPPzrL8tgcvOxLEatV1QPICghKm13EjEVgkeRftl8X6tqRyFv/9eKutczdD3sklMDOJfivoPD32D46Ww==",
       "cpu": [
         "ia32"
       ],
@@ -4420,9 +4420,9 @@
       }
     },
     "node_modules/esbuild-windows-64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.39.tgz",
-      "integrity": "sha512-E2wm+5FwCcLpKsBHRw28bSYQw0Ikxb7zIMxw3OPAkiaQhLVr3dnVO8DofmbWhhf6b97bWzg37iSZ45ZDpLw7Ow==",
+      "version": "0.14.41",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.41.tgz",
+      "integrity": "sha512-vLqmKbV8FJ7LFMrT3zEQpojnUUbXyqhRPVGnAYzc0ESY5yAuom4E9tL7KzZ5H8KEuCUf//AvbyxpE+yOcjpyjA==",
       "cpu": [
         "x64"
       ],
@@ -4436,9 +4436,9 @@
       }
     },
     "node_modules/esbuild-windows-arm64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.39.tgz",
-      "integrity": "sha512-sBZQz5D+Gd0EQ09tZRnz/PpVdLwvp/ufMtJ1iDFYddDaPpZXKqPyaxfYBLs3ueiaksQ26GGa7sci0OqFzNs7KA==",
+      "version": "0.14.41",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.41.tgz",
+      "integrity": "sha512-TOvj7kRTfpH4GPPmblvuMNf8oNJ3y2h7a6HttanVnc3QLMm5bNFYLSo6TShLOn0SbqFWGJwHIhGhw2JK96aVhg==",
       "cpu": [
         "arm64"
       ],
@@ -4974,7 +4974,7 @@
     "node_modules/expand-tilde": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
-      "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+      "integrity": "sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==",
       "dev": true,
       "dependencies": {
         "homedir-polyfill": "^1.0.1"
@@ -5024,7 +5024,7 @@
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
     "node_modules/fast-text-encoding": {
@@ -5162,9 +5162,9 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
-      "integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
       "funding": [
         {
           "type": "individual",
@@ -6862,9 +6862,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.4.tgz",
-      "integrity": "sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.5.tgz",
+      "integrity": "sha512-U9h1NLROZTq9uE1SNffn6WuPDg8icmi3ns4rEl/oTfIle4iLjTliCzgTsbaIFMq/Xn078/lfY/BL0GWZ+psK4Q=="
     },
     "node_modules/nopt": {
       "version": "1.0.10",
@@ -7033,9 +7033,9 @@
       "integrity": "sha1-rwt5f/6+r4pSxmN87b6IFs/sG8g="
     },
     "node_modules/object-inspect": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.1.tgz",
-      "integrity": "sha512-Y/jF6vnvEtOPGiKD1+q+X0CiUYRQtEHp89MLLUJ7TUivtH8Ugn2+3A7Rynqk7BRsAoqeOQWnFnjpDrKSxDgIGA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
+      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7404,7 +7404,7 @@
     "node_modules/patch-package/node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "node_modules/patch-package/node_modules/cross-spawn": {
       "version": "6.0.5",
@@ -7424,7 +7424,7 @@
     "node_modules/patch-package/node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "engines": {
         "node": ">=0.8.0"
       }
@@ -7835,7 +7835,7 @@
     "node_modules/qqjs/node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
     },
     "node_modules/qqjs/node_modules/cross-spawn": {
@@ -7857,7 +7857,7 @@
     "node_modules/qqjs/node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
@@ -9808,16 +9808,16 @@
       }
     },
     "@aws-sdk/client-s3": {
-      "version": "3.95.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.95.0.tgz",
-      "integrity": "sha512-IyPmgh5h8X5810buIcW0EqYZdm+MUN8FFugGQnpPFofhV77q9ISVS0XdsieZjBpZrFNg6qoSyvytwkGGGZP1IQ==",
+      "version": "3.100.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.100.0.tgz",
+      "integrity": "sha512-UmgFdJabWtiUS4dWsC3kZ+ZMvH5QUUbDnLS8pT12duwLGt+xlWPn3PUkV8kL6qjG6XePLUgCqFTLjDD4tsTZNg==",
       "requires": {
         "@aws-crypto/sha1-browser": "2.0.0",
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.95.0",
+        "@aws-sdk/client-sts": "3.100.0",
         "@aws-sdk/config-resolver": "3.80.0",
-        "@aws-sdk/credential-provider-node": "3.95.0",
+        "@aws-sdk/credential-provider-node": "3.100.0",
         "@aws-sdk/eventstream-serde-browser": "3.78.0",
         "@aws-sdk/eventstream-serde-config-resolver": "3.78.0",
         "@aws-sdk/eventstream-serde-node": "3.78.0",
@@ -9845,15 +9845,15 @@
         "@aws-sdk/node-http-handler": "3.94.0",
         "@aws-sdk/protocol-http": "3.78.0",
         "@aws-sdk/signature-v4-multi-region": "3.88.0",
-        "@aws-sdk/smithy-client": "3.85.0",
+        "@aws-sdk/smithy-client": "3.99.0",
         "@aws-sdk/types": "3.78.0",
         "@aws-sdk/url-parser": "3.78.0",
         "@aws-sdk/util-base64-browser": "3.58.0",
         "@aws-sdk/util-base64-node": "3.55.0",
         "@aws-sdk/util-body-length-browser": "3.55.0",
         "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.85.0",
-        "@aws-sdk/util-defaults-mode-node": "3.85.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.99.0",
+        "@aws-sdk/util-defaults-mode-node": "3.99.0",
         "@aws-sdk/util-stream-browser": "3.78.0",
         "@aws-sdk/util-stream-node": "3.78.0",
         "@aws-sdk/util-user-agent-browser": "3.78.0",
@@ -9868,9 +9868,9 @@
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.95.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.95.0.tgz",
-      "integrity": "sha512-yxiVyRG5ULTVzOTmlrsy1krjpBQo20+ZfQ9p++A7cA8dIsytzjlPLvtY+Pzz0pTa3h2B6tlVBmumgEQzh5Y8Ug==",
+      "version": "3.100.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.100.0.tgz",
+      "integrity": "sha512-nmBRUO5QfQ2IO8fHb37p8HT3n1ZooPb3sfTQejrpFH9Eq82VEOatIGt6yH3yTQ8+mhbabEhV5aY2wt/0D7wGVA==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -9888,15 +9888,15 @@
         "@aws-sdk/node-config-provider": "3.80.0",
         "@aws-sdk/node-http-handler": "3.94.0",
         "@aws-sdk/protocol-http": "3.78.0",
-        "@aws-sdk/smithy-client": "3.85.0",
+        "@aws-sdk/smithy-client": "3.99.0",
         "@aws-sdk/types": "3.78.0",
         "@aws-sdk/url-parser": "3.78.0",
         "@aws-sdk/util-base64-browser": "3.58.0",
         "@aws-sdk/util-base64-node": "3.55.0",
         "@aws-sdk/util-body-length-browser": "3.55.0",
         "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.85.0",
-        "@aws-sdk/util-defaults-mode-node": "3.85.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.99.0",
+        "@aws-sdk/util-defaults-mode-node": "3.99.0",
         "@aws-sdk/util-user-agent-browser": "3.78.0",
         "@aws-sdk/util-user-agent-node": "3.80.0",
         "@aws-sdk/util-utf8-browser": "3.55.0",
@@ -9905,14 +9905,14 @@
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.95.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.95.0.tgz",
-      "integrity": "sha512-qeoiEyBB5IQyjgjkCCBiQnISar7OJgjuTf2alM6ehjq8H4/T5VeMCeohEs5FR0/O60sJn40ZpL3YY/OmMh55UA==",
+      "version": "3.100.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.100.0.tgz",
+      "integrity": "sha512-WHy0e6COf6/LfMsYqG9H4SGaQRDjuckMtwOLtu6cYr4cro3bOU5pNuyEjAdUHCpuhZgiE6gkZozhTlxMJqIuRQ==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
         "@aws-sdk/config-resolver": "3.80.0",
-        "@aws-sdk/credential-provider-node": "3.95.0",
+        "@aws-sdk/credential-provider-node": "3.100.0",
         "@aws-sdk/fetch-http-handler": "3.78.0",
         "@aws-sdk/hash-node": "3.78.0",
         "@aws-sdk/invalid-dependency": "3.78.0",
@@ -9928,15 +9928,15 @@
         "@aws-sdk/node-config-provider": "3.80.0",
         "@aws-sdk/node-http-handler": "3.94.0",
         "@aws-sdk/protocol-http": "3.78.0",
-        "@aws-sdk/smithy-client": "3.85.0",
+        "@aws-sdk/smithy-client": "3.99.0",
         "@aws-sdk/types": "3.78.0",
         "@aws-sdk/url-parser": "3.78.0",
         "@aws-sdk/util-base64-browser": "3.58.0",
         "@aws-sdk/util-base64-node": "3.55.0",
         "@aws-sdk/util-body-length-browser": "3.55.0",
         "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.85.0",
-        "@aws-sdk/util-defaults-mode-node": "3.85.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.99.0",
+        "@aws-sdk/util-defaults-mode-node": "3.99.0",
         "@aws-sdk/util-user-agent-browser": "3.78.0",
         "@aws-sdk/util-user-agent-node": "3.80.0",
         "@aws-sdk/util-utf8-browser": "3.55.0",
@@ -9981,13 +9981,13 @@
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.95.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.95.0.tgz",
-      "integrity": "sha512-Ditfnmo8/F79Zj8HmaRZZTDsthhvKcdgGFus+pF3kxZxyR3YU/k7/eGUISZeCQhA0/9nwxXMFDUmAIsa0AMfyg==",
+      "version": "3.100.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.100.0.tgz",
+      "integrity": "sha512-2pCtth/Iv4mATRwb2g1nJdd9TolMyhTnhcskopukFvzp13VS5cgtz0hgYmJNnztTF8lpKJhJaidtKS5JJTWnHg==",
       "requires": {
         "@aws-sdk/credential-provider-env": "3.78.0",
         "@aws-sdk/credential-provider-imds": "3.81.0",
-        "@aws-sdk/credential-provider-sso": "3.95.0",
+        "@aws-sdk/credential-provider-sso": "3.100.0",
         "@aws-sdk/credential-provider-web-identity": "3.78.0",
         "@aws-sdk/property-provider": "3.78.0",
         "@aws-sdk/shared-ini-file-loader": "3.80.0",
@@ -9996,15 +9996,15 @@
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.95.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.95.0.tgz",
-      "integrity": "sha512-NCXejOQg5p+oJPaUPa+jIrU7pStm8zZtOn6lXVnubZrQClv2+ZQrgxVt6otN464SWqMQbmLFYNyYf4bsLJaEhA==",
+      "version": "3.100.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.100.0.tgz",
+      "integrity": "sha512-PMIPnn/dhv9tlWR0qXnANJpTumujWfhKnLAsV3BUqB1K9IzWqz/zXjCT0jcSUTY8X/VkSuehtBdCKvOOM5mMqg==",
       "requires": {
         "@aws-sdk/credential-provider-env": "3.78.0",
         "@aws-sdk/credential-provider-imds": "3.81.0",
-        "@aws-sdk/credential-provider-ini": "3.95.0",
+        "@aws-sdk/credential-provider-ini": "3.100.0",
         "@aws-sdk/credential-provider-process": "3.80.0",
-        "@aws-sdk/credential-provider-sso": "3.95.0",
+        "@aws-sdk/credential-provider-sso": "3.100.0",
         "@aws-sdk/credential-provider-web-identity": "3.78.0",
         "@aws-sdk/property-provider": "3.78.0",
         "@aws-sdk/shared-ini-file-loader": "3.80.0",
@@ -10024,11 +10024,11 @@
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.95.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.95.0.tgz",
-      "integrity": "sha512-YIzBBWUKkazvoM8CsCbf4YIs5ENtOr5KXUd6e993c3oRMNsUykOtf/AUBN6G3HItuyxoA8vW/8M6tKX44cRCAg==",
+      "version": "3.100.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.100.0.tgz",
+      "integrity": "sha512-DwJvrh77vBJ1/fS9z0i2QuIvSk4pATA4DH8AEWoQ8LQX97tp3es7gZV5Wu93wFsEyIYC8penz6pNVq5QajMk2A==",
       "requires": {
-        "@aws-sdk/client-sso": "3.95.0",
+        "@aws-sdk/client-sso": "3.100.0",
         "@aws-sdk/property-provider": "3.78.0",
         "@aws-sdk/shared-ini-file-loader": "3.80.0",
         "@aws-sdk/types": "3.78.0",
@@ -10397,16 +10397,16 @@
       }
     },
     "@aws-sdk/s3-request-presigner": {
-      "version": "3.95.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.95.0.tgz",
-      "integrity": "sha512-mZPE/AAHcXAnIR41AV7FeKj2YPclYPp0vccrYQW/pQHgyMSVXcQQm52XnG2FwIjAK+BH4/fgCqYXevc7kOpi+g==",
+      "version": "3.100.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.100.0.tgz",
+      "integrity": "sha512-32j9o2ChP2pzsua5+Ci9XFKBsFXxlE5muVD9CSpEG9UfUieORAvXsZVChu86IWBFR2nQRm0vebrwJC2tKsgu1A==",
       "requires": {
         "@aws-sdk/middleware-sdk-s3": "3.86.0",
         "@aws-sdk/protocol-http": "3.78.0",
         "@aws-sdk/signature-v4-multi-region": "3.88.0",
-        "@aws-sdk/smithy-client": "3.85.0",
+        "@aws-sdk/smithy-client": "3.99.0",
         "@aws-sdk/types": "3.78.0",
-        "@aws-sdk/util-create-request": "3.85.0",
+        "@aws-sdk/util-create-request": "3.99.0",
         "@aws-sdk/util-format-url": "3.78.0",
         "tslib": "^2.3.1"
       }
@@ -10450,9 +10450,9 @@
       }
     },
     "@aws-sdk/smithy-client": {
-      "version": "3.85.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.85.0.tgz",
-      "integrity": "sha512-Ox/yQEAnANzhpJMyrpuxWtF/i3EviavENczT7fo4uwSyZTz/sfSBQNjs/YAG1UeA6uOI3pBP5EaFERV5hr2fRA==",
+      "version": "3.99.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.99.0.tgz",
+      "integrity": "sha512-N9xgCcwbOBZ4/WuROzlErExXV6+vFrFkNJzeBT31/avvrHXjxgxwQlMoXoQCfM8PyRuDuVSfZeoh1iIRfoxidA==",
       "requires": {
         "@aws-sdk/middleware-stack": "3.78.0",
         "@aws-sdk/types": "3.78.0",
@@ -10533,20 +10533,20 @@
       }
     },
     "@aws-sdk/util-create-request": {
-      "version": "3.85.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-create-request/-/util-create-request-3.85.0.tgz",
-      "integrity": "sha512-AQrG+mIgjtcN23O4zCAWpIwyPIHzKZAcPbF8OROAbNcQcMwyg2Q9hyodRR5l3fzGG2jiRt9P3copvORBWB7diA==",
+      "version": "3.99.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-create-request/-/util-create-request-3.99.0.tgz",
+      "integrity": "sha512-7+jM8xe2u5FW7ufRqHTmvJa7nH9f8uZXuWpHcmITKm8IRnkst1ib1DUctEZE+go9lnonzy4TttSNMt5NqFCgOA==",
       "requires": {
         "@aws-sdk/middleware-stack": "3.78.0",
-        "@aws-sdk/smithy-client": "3.85.0",
+        "@aws-sdk/smithy-client": "3.99.0",
         "@aws-sdk/types": "3.78.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.85.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.85.0.tgz",
-      "integrity": "sha512-oqK/e2pHuMWrvTJWtDBzylbj232ezlTay5dCq4RQlyi3LPPVBQ08haYD1Mk2ikQ/qa0XvbSD6YVhjpTlvwRNjw==",
+      "version": "3.99.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.99.0.tgz",
+      "integrity": "sha512-qSYjUGuN8n7Q/zAi0tzU4BrU389jQosXtjp7eHpLATl0pKGpaHx6rJNwbiNhvBhBEfmSgqsJ09b4gZUpUezHEw==",
       "requires": {
         "@aws-sdk/property-provider": "3.78.0",
         "@aws-sdk/types": "3.78.0",
@@ -10555,9 +10555,9 @@
       }
     },
     "@aws-sdk/util-defaults-mode-node": {
-      "version": "3.85.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.85.0.tgz",
-      "integrity": "sha512-KDNl4H8jJJLh6y7I3MSwRKe4plKbFKK8MVkS0+Fce/GJh4EnqxF0HzMMaSeNUcPvO2wHRq2a60+XW+0d7eWo1A==",
+      "version": "3.99.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.99.0.tgz",
+      "integrity": "sha512-8TUO0kEnQcgT1gAW9y9oO6a5gKhfEGEUeKidEgbTczEUrjr3aCXIC+p0DI5FJfImwPrTKXra8A22utDM92phWw==",
       "requires": {
         "@aws-sdk/config-resolver": "3.80.0",
         "@aws-sdk/credential-provider-imds": "3.81.0",
@@ -10740,13 +10740,13 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
           "dev": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
           "dev": true
         },
         "has-flag": {
@@ -10900,9 +10900,9 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
     },
     "@nimbella/nimbella-deployer": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.1.1.tgz",
-      "integrity": "sha512-etDFwNRp+Vxd7x78vHXpFu3XLxtDANLOvAnw1MFiAqg6nLOQKqMXZ6qBRO/9WNjnTG3CzhfPMNBrvnWriwJ10Q==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.2.0.tgz",
+      "integrity": "sha512-Q4G5VKpqJG4nwLBn4iUgiGoiKMuld0f7pX91YaKjkCl049w/B0u8XF6+PlfLSMgSicNLLplRzLkzO5gbONoyZg==",
       "requires": {
         "@aws-sdk/client-s3": "^3.27.0",
         "@nimbella/sdk": "^1.3.5",
@@ -11239,7 +11239,7 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
         },
         "emoji-regex": {
           "version": "7.0.3",
@@ -11249,7 +11249,7 @@
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
         },
         "has-flag": {
           "version": "3.0.0",
@@ -11979,13 +11979,13 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
           "dev": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
           "dev": true
         },
         "has-flag": {
@@ -12227,9 +12227,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001342",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001342.tgz",
-      "integrity": "sha512-bn6sOCu7L7jcbBbyNhLg0qzXdJ/PMbybZTH/BA6Roet9wxYRm6Tr9D0s0uhLkOZ6MSG+QU6txUgdpr3MXIVqjA=="
+      "version": "1.0.30001344",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001344.tgz",
+      "integrity": "sha512-0ZFjnlCaXNOAYcV7i+TtdKBp0L/3XEU2MF/x6Du1lrh+SRX4IfzIVL4HNJg5pB2PmFb8rszIGyOvsZnqqRoc2g=="
     },
     "cardinal": {
       "version": "2.1.1",
@@ -12416,7 +12416,7 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
         }
       }
     },
@@ -12478,7 +12478,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "configstore": {
       "version": "5.0.1",
@@ -12531,7 +12531,7 @@
     "crypt": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow=="
     },
     "crypto-random-string": {
       "version": "2.0.0",
@@ -12590,7 +12590,7 @@
     "detect-file": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
-      "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
+      "integrity": "sha512-DtCOLG98P007x7wiiOmfI0fi3eIKyWiLTGJ2MDnVi/E04lWGbf+JzrRHMm0rgIIZJGtHpKpbVgLWHrv8xXpc3Q==",
       "dev": true
     },
     "detect-indent": {
@@ -12649,9 +12649,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.137",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz",
-      "integrity": "sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA=="
+      "version": "1.4.141",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.141.tgz",
+      "integrity": "sha512-mfBcbqc0qc6RlxrsIgLG2wCqkiPAjEezHxGTu7p3dHHFOurH4EjS9rFZndX5axC8264rI1Pcbw8uQP39oZckeA=="
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -12692,7 +12692,7 @@
     "ent": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
-      "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0="
+      "integrity": "sha512-GHrMyVZQWvTIdDtpiEXdHZnFQKzeO09apj8Cbl4pKWy4i0Oprcq17usfDt5aO63swf0JOeMWjWQE/LzgSRuWpA=="
     },
     "entities": {
       "version": "2.2.0",
@@ -12772,141 +12772,141 @@
     "es6-promisify": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
       "requires": {
         "es6-promise": "^4.0.3"
       }
     },
     "esbuild": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.39.tgz",
-      "integrity": "sha512-2kKujuzvRWYtwvNjYDY444LQIA3TyJhJIX3Yo4+qkFlDDtGlSicWgeHVJqMUP/2sSfH10PGwfsj+O2ro1m10xQ==",
+      "version": "0.14.41",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.41.tgz",
+      "integrity": "sha512-uZl2CH5nwayLPi1Unhfk+vBBjD3FDlYQ+v24qAlj2oZMYQP8pFs1k3DK5ViD+keF3JnuV4K7JtqVvBmTDwVEbA==",
       "dev": true,
       "requires": {
-        "esbuild-android-64": "0.14.39",
-        "esbuild-android-arm64": "0.14.39",
-        "esbuild-darwin-64": "0.14.39",
-        "esbuild-darwin-arm64": "0.14.39",
-        "esbuild-freebsd-64": "0.14.39",
-        "esbuild-freebsd-arm64": "0.14.39",
-        "esbuild-linux-32": "0.14.39",
-        "esbuild-linux-64": "0.14.39",
-        "esbuild-linux-arm": "0.14.39",
-        "esbuild-linux-arm64": "0.14.39",
-        "esbuild-linux-mips64le": "0.14.39",
-        "esbuild-linux-ppc64le": "0.14.39",
-        "esbuild-linux-riscv64": "0.14.39",
-        "esbuild-linux-s390x": "0.14.39",
-        "esbuild-netbsd-64": "0.14.39",
-        "esbuild-openbsd-64": "0.14.39",
-        "esbuild-sunos-64": "0.14.39",
-        "esbuild-windows-32": "0.14.39",
-        "esbuild-windows-64": "0.14.39",
-        "esbuild-windows-arm64": "0.14.39"
+        "esbuild-android-64": "0.14.41",
+        "esbuild-android-arm64": "0.14.41",
+        "esbuild-darwin-64": "0.14.41",
+        "esbuild-darwin-arm64": "0.14.41",
+        "esbuild-freebsd-64": "0.14.41",
+        "esbuild-freebsd-arm64": "0.14.41",
+        "esbuild-linux-32": "0.14.41",
+        "esbuild-linux-64": "0.14.41",
+        "esbuild-linux-arm": "0.14.41",
+        "esbuild-linux-arm64": "0.14.41",
+        "esbuild-linux-mips64le": "0.14.41",
+        "esbuild-linux-ppc64le": "0.14.41",
+        "esbuild-linux-riscv64": "0.14.41",
+        "esbuild-linux-s390x": "0.14.41",
+        "esbuild-netbsd-64": "0.14.41",
+        "esbuild-openbsd-64": "0.14.41",
+        "esbuild-sunos-64": "0.14.41",
+        "esbuild-windows-32": "0.14.41",
+        "esbuild-windows-64": "0.14.41",
+        "esbuild-windows-arm64": "0.14.41"
       }
     },
     "esbuild-android-64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.39.tgz",
-      "integrity": "sha512-EJOu04p9WgZk0UoKTqLId9VnIsotmI/Z98EXrKURGb3LPNunkeffqQIkjS2cAvidh+OK5uVrXaIP229zK6GvhQ==",
+      "version": "0.14.41",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.41.tgz",
+      "integrity": "sha512-byyo8LPOGHzAqxbwh2Q72d7L+rXXTsr/KALjsiCySrJ60CGMe80i3bwoQ+WODxsGaH08R//yg5oc7xHKgQz4uw==",
       "dev": true,
       "optional": true
     },
     "esbuild-android-arm64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.39.tgz",
-      "integrity": "sha512-+twajJqO7n3MrCz9e+2lVOnFplRsaGRwsq1KL/uOy7xK7QdRSprRQcObGDeDZUZsacD5gUkk6OiHiYp6RzU3CA==",
+      "version": "0.14.41",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.41.tgz",
+      "integrity": "sha512-7koo9Dm/mwK4M8PGQX8JQRc4UQ4Wj7DT1nD4BQkVs2jxtHbYOlnsQH0fneKSXZVmnBIHYcntr/e1VU5gnYLvGQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-darwin-64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.39.tgz",
-      "integrity": "sha512-ImT6eUw3kcGcHoUxEcdBpi6LfTRWaV6+qf32iYYAfwOeV+XaQ/Xp5XQIBiijLeo+LpGci9M0FVec09nUw41a5g==",
+      "version": "0.14.41",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.41.tgz",
+      "integrity": "sha512-kW8fC2auh9jjmBXudTmlMfbBCMYMuujhxG40CxMhKiQ8NLBK4RU9yUYY6ss7QJp24kVTtKd4IvfwOio9SE53MA==",
       "dev": true,
       "optional": true
     },
     "esbuild-darwin-arm64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.39.tgz",
-      "integrity": "sha512-/fcQ5UhE05OiT+bW5v7/up1bDsnvaRZPJxXwzXsMRrr7rZqPa85vayrD723oWMT64dhrgWeA3FIneF8yER0XTw==",
+      "version": "0.14.41",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.41.tgz",
+      "integrity": "sha512-cO0EPkiQt0bERH9sZFIoTywWfGhEpshdpvQpDfLh/ZJLeioQfaarM9YDrmID+f7k77djh0mdyfsC6XpS0HlLsw==",
       "dev": true,
       "optional": true
     },
     "esbuild-freebsd-64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.39.tgz",
-      "integrity": "sha512-oMNH8lJI4wtgN5oxuFP7BQ22vgB/e3Tl5Woehcd6i2r6F3TszpCnNl8wo2d/KvyQ4zvLvCWAlRciumhQg88+kQ==",
+      "version": "0.14.41",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.41.tgz",
+      "integrity": "sha512-6tsMDK6b7czCOjsr68BgVogFXcTCWL3T7yFXRFuAmXwY9ybYgX8sybD7ztrRB03dLAPeMxHo+PzeMD6LdVrLdQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-freebsd-arm64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.39.tgz",
-      "integrity": "sha512-1GHK7kwk57ukY2yI4ILWKJXaxfr+8HcM/r/JKCGCPziIVlL+Wi7RbJ2OzMcTKZ1HpvEqCTBT/J6cO4ZEwW4Ypg==",
+      "version": "0.14.41",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.41.tgz",
+      "integrity": "sha512-AQ2S/VCLKVBe/+HNiFLyp3w9i7AEtCOWEzKHSkfHk0VO5bPzHd7WJfWmj1Bxliu7vdPESbiDUTJIH3rDt4bzSA==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-32": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.39.tgz",
-      "integrity": "sha512-g97Sbb6g4zfRLIxHgW2pc393DjnkTRMeq3N1rmjDUABxpx8SjocK4jLen+/mq55G46eE2TA0MkJ4R3SpKMu7dg==",
+      "version": "0.14.41",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.41.tgz",
+      "integrity": "sha512-sb7Kah5Px6BNZ6gzm0nJLuDeAJKbIlaKIoI9zgZ5dFDxZSn91TMAHJz5W39YDJ8+ZaGJYIdqZSpDo+4G769mZw==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.39.tgz",
-      "integrity": "sha512-4tcgFDYWdI+UbNMGlua9u1Zhu0N5R6u9tl5WOM8aVnNX143JZoBZLpCuUr5lCKhnD0SCO+5gUyMfupGrHtfggQ==",
+      "version": "0.14.41",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.41.tgz",
+      "integrity": "sha512-PeI0bfbv+5ondZRhPRszptp3RQRRAPxpOB2CYDphKske5+UlCXPi4Af+T++OqhV5TEpymTfxJdJQ1sn1w32coA==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-arm": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.39.tgz",
-      "integrity": "sha512-t0Hn1kWVx5UpCzAJkKRfHeYOLyFnXwYynIkK54/h3tbMweGI7dj400D1k0Vvtj2u1P+JTRT9tx3AjtLEMmfVBQ==",
+      "version": "0.14.41",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.41.tgz",
+      "integrity": "sha512-8DQ6Sv3XNwgu0cnPA3q+kJSqfOYLDqWzpW8dPF+/Or23bS/5EIT/CzN73uIhR8A3AokXIczn88VKti7Xtv+V2g==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-arm64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.39.tgz",
-      "integrity": "sha512-23pc8MlD2D6Px1mV8GMglZlKgwgNKAO8gsgsLLcXWSs9lQsCYkIlMo/2Ycfo5JrDIbLdwgP8D2vpfH2KcBqrDQ==",
+      "version": "0.14.41",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.41.tgz",
+      "integrity": "sha512-aAhBX6kVG8hTVuANE90ORobioHdpZLzy8Fibf4XBuG4IuJfjgM5N4wFIq2Tpd+Ykit432PL/YOQhZ4W6nVc4cQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-mips64le": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.39.tgz",
-      "integrity": "sha512-epwlYgVdbmkuRr5n4es3B+yDI0I2e/nxhKejT9H0OLxFAlMkeQZxSpxATpDc9m8NqRci6Kwyb/SfmD1koG2Zuw==",
+      "version": "0.14.41",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.41.tgz",
+      "integrity": "sha512-88xo4FRYQ2laMJnrqZu8j5q531XT/odZnhO5NLWO/NdweIdT8F+QL0fNIBIf+nVkC1d0Psgmt+g35GAODMDl8g==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-ppc64le": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.39.tgz",
-      "integrity": "sha512-W/5ezaq+rQiQBThIjLMNjsuhPHg+ApVAdTz2LvcuesZFMsJoQAW2hutoyg47XxpWi7aEjJGrkS26qCJKhRn3QQ==",
+      "version": "0.14.41",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.41.tgz",
+      "integrity": "sha512-kJ0r/Cg3LzFzHhbBsvqi/hDPGKMGzFiPGOmUvqTkfVXhRUQtOMkXkyKdP7OEMRb8ctPtnptsZOOXPHRdU0NdJQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-riscv64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.39.tgz",
-      "integrity": "sha512-IS48xeokcCTKeQIOke2O0t9t14HPvwnZcy+5baG13Z1wxs9ZrC5ig5ypEQQh4QMKxURD5TpCLHw2W42CLuVZaA==",
+      "version": "0.14.41",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.41.tgz",
+      "integrity": "sha512-ZJ7d/qFRx14J3aP75ccrFSZyuYZ1hu8IVfwVqyQg4jQFgNME2FMz7pZMskBJ0fSW8QcYUnN3RubFXWijyjKUug==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-s390x": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.39.tgz",
-      "integrity": "sha512-zEfunpqR8sMomqXhNTFEKDs+ik7HC01m3M60MsEjZOqaywHu5e5682fMsqOlZbesEAAaO9aAtRBsU7CHnSZWyA==",
+      "version": "0.14.41",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.41.tgz",
+      "integrity": "sha512-xeWAEZt1jAfYkYuyIUuHKpH/oj7O862Je5HTH9E+4sEfoOnZaAmFrisbXjGDKXjMRKYscFlM8wXdNBmiqQlT8g==",
       "dev": true,
       "optional": true
     },
     "esbuild-netbsd-64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.39.tgz",
-      "integrity": "sha512-Uo2suJBSIlrZCe4E0k75VDIFJWfZy+bOV6ih3T4MVMRJh1lHJ2UyGoaX4bOxomYN3t+IakHPyEoln1+qJ1qYaA==",
+      "version": "0.14.41",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.41.tgz",
+      "integrity": "sha512-X/UE3Asqy594/atYi/STgYtaMQBJwtZKF0KFFdJTkwb6rtaoHCM1o482iHibgnSK7CicuRhyTZ+cNx4OFqRQAg==",
       "dev": true,
       "optional": true
     },
@@ -12929,37 +12929,37 @@
       }
     },
     "esbuild-openbsd-64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.39.tgz",
-      "integrity": "sha512-secQU+EpgUPpYjJe3OecoeGKVvRMLeKUxSMGHnK+aK5uQM3n1FPXNJzyz1LHFOo0WOyw+uoCxBYdM4O10oaCAA==",
+      "version": "0.14.41",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.41.tgz",
+      "integrity": "sha512-6m+1dtdO+4KaU3R0UTT82hxWxWpFCjgSHhQl/PKtMmq+CvvxRQDcTwujLC843M7ChGVWNM2q1s6YCwoA0WQ9kw==",
       "dev": true,
       "optional": true
     },
     "esbuild-sunos-64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.39.tgz",
-      "integrity": "sha512-qHq0t5gePEDm2nqZLb+35p/qkaXVS7oIe32R0ECh2HOdiXXkj/1uQI9IRogGqKkK+QjDG+DhwiUw7QoHur/Rwg==",
+      "version": "0.14.41",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.41.tgz",
+      "integrity": "sha512-p96tTTcE8/WY7A4Udh+fxVUTGL8rIXOpyxyhZiXug+f7DGbjE24PbewqgIBRSDyM7xRUty+1RzqyJz73YIV6yg==",
       "dev": true,
       "optional": true
     },
     "esbuild-windows-32": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.39.tgz",
-      "integrity": "sha512-XPjwp2OgtEX0JnOlTgT6E5txbRp6Uw54Isorm3CwOtloJazeIWXuiwK0ONJBVb/CGbiCpS7iP2UahGgd2p1x+Q==",
+      "version": "0.14.41",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.41.tgz",
+      "integrity": "sha512-jS+/pGyPPzrL8tgcvOxLEatV1QPICghKm13EjEVgkeRftl8X6tqRyFv/9eKutczdD3sklMDOJfivoPD32D46Ww==",
       "dev": true,
       "optional": true
     },
     "esbuild-windows-64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.39.tgz",
-      "integrity": "sha512-E2wm+5FwCcLpKsBHRw28bSYQw0Ikxb7zIMxw3OPAkiaQhLVr3dnVO8DofmbWhhf6b97bWzg37iSZ45ZDpLw7Ow==",
+      "version": "0.14.41",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.41.tgz",
+      "integrity": "sha512-vLqmKbV8FJ7LFMrT3zEQpojnUUbXyqhRPVGnAYzc0ESY5yAuom4E9tL7KzZ5H8KEuCUf//AvbyxpE+yOcjpyjA==",
       "dev": true,
       "optional": true
     },
     "esbuild-windows-arm64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.39.tgz",
-      "integrity": "sha512-sBZQz5D+Gd0EQ09tZRnz/PpVdLwvp/ufMtJ1iDFYddDaPpZXKqPyaxfYBLs3ueiaksQ26GGa7sci0OqFzNs7KA==",
+      "version": "0.14.41",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.41.tgz",
+      "integrity": "sha512-TOvj7kRTfpH4GPPmblvuMNf8oNJ3y2h7a6HttanVnc3QLMm5bNFYLSo6TShLOn0SbqFWGJwHIhGhw2JK96aVhg==",
       "dev": true,
       "optional": true
     },
@@ -13347,7 +13347,7 @@
     "expand-tilde": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
-      "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+      "integrity": "sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==",
       "dev": true,
       "requires": {
         "homedir-polyfill": "^1.0.1"
@@ -13388,7 +13388,7 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
     "fast-text-encoding": {
@@ -13501,9 +13501,9 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "follow-redirects": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
-      "integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ=="
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA=="
     },
     "fs-constants": {
       "version": "1.0.0",
@@ -14768,9 +14768,9 @@
       "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="
     },
     "node-releases": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.4.tgz",
-      "integrity": "sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.5.tgz",
+      "integrity": "sha512-U9h1NLROZTq9uE1SNffn6WuPDg8icmi3ns4rEl/oTfIle4iLjTliCzgTsbaIFMq/Xn078/lfY/BL0GWZ+psK4Q=="
     },
     "nopt": {
       "version": "1.0.10",
@@ -14900,9 +14900,9 @@
       "integrity": "sha1-rwt5f/6+r4pSxmN87b6IFs/sG8g="
     },
     "object-inspect": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.1.tgz",
-      "integrity": "sha512-Y/jF6vnvEtOPGiKD1+q+X0CiUYRQtEHp89MLLUJ7TUivtH8Ugn2+3A7Rynqk7BRsAoqeOQWnFnjpDrKSxDgIGA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
+      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
       "dev": true
     },
     "object-keys": {
@@ -15173,7 +15173,7 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
         },
         "cross-spawn": {
           "version": "6.0.5",
@@ -15190,7 +15190,7 @@
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
         },
         "fs-extra": {
           "version": "7.0.1",
@@ -15500,7 +15500,7 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
           "dev": true
         },
         "cross-spawn": {
@@ -15519,7 +15519,7 @@
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
           "dev": true
         },
         "execa": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/nimbella-cli",
-  "version": "3.1.1",
+  "version": "4.0.0",
   "description": "A comprehensive CLI for the Nimbella stack",
   "main": "lib/index.js",
   "repository": {
@@ -16,7 +16,7 @@
   "dependencies": {
     "@adobe/aio-cli-plugin-runtime": "github:nimbella/aio-cli-plugin-runtime#v2021-11-19-1",
     "@adobe/aio-lib-core-config": "^2.0.0",
-    "@nimbella/nimbella-deployer": "4.1.1",
+    "@nimbella/nimbella-deployer": "4.2.0",
     "@nimbella/storage": "^0.0.7",
     "@oclif/command": "^1",
     "@oclif/config": "^1",

--- a/src/commands/project/get-metadata.ts
+++ b/src/commands/project/get-metadata.ts
@@ -14,7 +14,7 @@
 import { flags } from '@oclif/command'
 import {
   readProject, Flags, isGithubRef, getGithubAuth, authPersister, inBrowser, makeIncluder,
-  getRuntimeForAction
+  getRuntimeForAction, renameActionsToFunctions
 } from '@nimbella/nimbella-deployer'
 
 import { NimBaseCommand, NimLogger, branding } from '../../NimBaseCommand'
@@ -77,6 +77,7 @@ export class ProjectMetadata extends NimBaseCommand {
     }
 
     // Display result
+    renameActionsToFunctions(result)
     logger.logJSON(result)
   }
 }

--- a/src/generator/project.ts
+++ b/src/generator/project.ts
@@ -15,7 +15,10 @@ import * as fs from 'fs'
 import * as path from 'path'
 import * as yaml from 'js-yaml'
 import * as rimraf from 'rimraf'
-import { DeployStructure, PackageSpec, ActionSpec, fileExtensionForRuntime, initRuntimes, isValidRuntime } from '@nimbella/nimbella-deployer'
+import {
+  DeployStructure, PackageSpec, ActionSpec, fileExtensionForRuntime, initRuntimes,
+  renameActionsToFunctions, isValidRuntime
+} from '@nimbella/nimbella-deployer'
 import { samples } from './samples'
 import { branding } from '../NimBaseCommand'
 
@@ -55,6 +58,7 @@ export async function createProject(project: string, flags: any, logger: any): P
     generateSample(kind, projectConfig, sampleText, samplePackage)
   }
   // Write the config.
+  renameActionsToFunctions(projectConfig)
   const data = yaml.safeDump(projectConfig)
   fs.writeFileSync(configFile, data)
   // Add the .gitignore
@@ -85,7 +89,7 @@ function createProjectPackage(samplePackage: string) {
 // Make a more fully populated config (with defaults filled in and comments)
 // TODO we don't have an internal representation of comments, so we punt on that for the moment.
 function configTemplate(): DeployStructure {
-  const config: DeployStructure = { targetNamespace: '', parameters: {}, packages: [] }
+  const config: DeployStructure = { environment: {}, parameters: {}, packages: [] }
   const defPkg: PackageSpec = { name: 'sample', environment: {}, parameters: {}, annotations: {}, actions: [] }
   config.packages.push(defPkg)
   return config


### PR DESCRIPTION
This change declares a new major release of the CLI (4.0.0) incorporating a new release of the deployer (4.2.0).   There are three changes.

1.  The status directory generated by the deployer in the base of a deployed project is now called `.deployed` rather than `.nimbella`.    This change is backward compatible _for the most part_ in that both `.nimbella` and `.deployed` continue to be ignored by the deployer during project reading.   However, only `.deployed` will be generated and only `deployed` will be re-read during incremental deploys, so there can be a one-time hiccup in incremental deployment where the entire project is deployed.
2. The parsing of `project.yml` now accepts both `functions` and `actions` where only `actions` was accepted before.   This is also a backwards-compatible change (`actions` continues to be accepted).
3. The generation of a project configuration output, both in `nim project create` and `nim project get-metadata`, will use `functions` rather than `actions`.   _This is a breaking change for tools that expect to parse the `get-metadata` output_.