### PR TITLE
Fix remote verbose build behavior

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@nimbella/nimbella-cli",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nimbella/nimbella-cli",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/aio-cli-plugin-runtime": "github:nimbella/aio-cli-plugin-runtime#v2021-11-19-1",
         "@adobe/aio-lib-core-config": "^2.0.0",
-        "@nimbella/nimbella-deployer": "4.2.0",
+        "@nimbella/nimbella-deployer": "4.2.1",
         "@nimbella/storage": "^0.0.7",
         "@oclif/command": "^1",
         "@oclif/config": "^1",
@@ -1686,9 +1686,9 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
     },
     "node_modules/@nimbella/nimbella-deployer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.2.0.tgz",
-      "integrity": "sha512-Q4G5VKpqJG4nwLBn4iUgiGoiKMuld0f7pX91YaKjkCl049w/B0u8XF6+PlfLSMgSicNLLplRzLkzO5gbONoyZg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.2.1.tgz",
+      "integrity": "sha512-WVeG9f0wD07idaqGm3PQdrMZ5uf9N77bz1amJc6QkmzC6pXtfO1RQfazUH1c6eg/YEp1/fPzAYqV6HdLtCv42g==",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.27.0",
         "@nimbella/sdk": "^1.3.5",
@@ -10900,9 +10900,9 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
     },
     "@nimbella/nimbella-deployer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.2.0.tgz",
-      "integrity": "sha512-Q4G5VKpqJG4nwLBn4iUgiGoiKMuld0f7pX91YaKjkCl049w/B0u8XF6+PlfLSMgSicNLLplRzLkzO5gbONoyZg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.2.1.tgz",
+      "integrity": "sha512-WVeG9f0wD07idaqGm3PQdrMZ5uf9N77bz1amJc6QkmzC6pXtfO1RQfazUH1c6eg/YEp1/fPzAYqV6HdLtCv42g==",
       "requires": {
         "@aws-sdk/client-s3": "^3.27.0",
         "@nimbella/sdk": "^1.3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/nimbella-cli",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "A comprehensive CLI for the Nimbella stack",
   "main": "lib/index.js",
   "repository": {
@@ -16,7 +16,7 @@
   "dependencies": {
     "@adobe/aio-cli-plugin-runtime": "github:nimbella/aio-cli-plugin-runtime#v2021-11-19-1",
     "@adobe/aio-lib-core-config": "^2.0.0",
-    "@nimbella/nimbella-deployer": "4.2.0",
+    "@nimbella/nimbella-deployer": "4.2.1",
     "@nimbella/storage": "^0.0.7",
     "@oclif/command": "^1",
     "@oclif/config": "^1",


### PR DESCRIPTION
Incorporates deployer 4.2.1 with the fix and declares version 4.0.1

Previous to this fix, the combination of `--verbose-build`, `--remote-build` and an actual build failure would incorrectly cause the build transcript to be omitted. 