### PR TITLE
Make the user agent string tailorable via the process environment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nimbella/nimbella-cli",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nimbella/nimbella-cli",
-      "version": "4.0.2",
+      "version": "4.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/aio-cli-plugin-runtime": "github:nimbella/aio-cli-plugin-runtime#v2021-11-19-1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/nimbella-cli",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "description": "A comprehensive CLI for the Nimbella stack",
   "main": "lib/index.js",
   "repository": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,7 +21,7 @@ export async function run(): Promise<void> {
   const topics = pj.oclif.topics
   const topicNames = Object.keys(topics)
   // Compute user agent
-  const userAgent = 'nimbella-cli/' + pj.version
+  const userAgent = process.env.NIM_USER_AGENT || 'nimbella-cli/' + pj.version
   // Initialize the API environment
   initializeAPI(userAgent)
   // Split an initial colon-separated topic:command token if found.  As the topic portion could be an alias, we look for that case also


### PR DESCRIPTION
When using Nimbella CLI or Nimbella Deployer via library interfaces, there is an opportunity to set the user agent string on the `initializeAPI` call.   But, when invoking the CLI at a terminal, the `initializeAPI` call has so far used a hard-coded constant so there is no opportunity to tailor the user agent string by context.  

This change introduces the environment variable `NIM_USER_AGENT` which can be used to set an alternative user agent string.   If the environment variable is unset (or set to the empty string), then the hard-coded constant is used as before.

The change is motivated by the fact that `nim` is often used in a context where it is embedded in something else and the generic user agent string is not informative enough.