### PR TITLE
Support for triggers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@adobe/aio-cli-plugin-runtime": "github:nimbella/aio-cli-plugin-runtime#v2021-11-19-1",
         "@adobe/aio-lib-core-config": "^2.0.0",
         "@adobe/aio-lib-runtime": "^3.3.0",
-        "@nimbella/nimbella-deployer": "4.2.1",
+        "@nimbella/nimbella-deployer": "4.3.1",
         "@nimbella/storage": "^0.0.7",
         "@oclif/command": "^1",
         "@oclif/config": "^1",
@@ -1755,9 +1755,9 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
     },
     "node_modules/@nimbella/nimbella-deployer": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.2.1.tgz",
-      "integrity": "sha512-WVeG9f0wD07idaqGm3PQdrMZ5uf9N77bz1amJc6QkmzC6pXtfO1RQfazUH1c6eg/YEp1/fPzAYqV6HdLtCv42g==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.3.1.tgz",
+      "integrity": "sha512-OvDeN9I0ymexk4gtIewYj4wjfVpJh3Y6g3miLQx/Fwvel21wfvGWWRF6fKnANE8VPRdpYMwYIuxM6+JNIKO6KA==",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.27.0",
         "@nimbella/sdk": "^1.3.5",
@@ -1768,6 +1768,7 @@
         "archiver": "^5.3.0",
         "atob": "^2.1.2",
         "axios": "^0.21.4",
+        "cron-validator": "^1.3.1",
         "debug": "^4.1.1",
         "dotenv": "^16.0.1",
         "ignore": "5.0.6",
@@ -3818,6 +3819,11 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/cron-validator": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/cron-validator/-/cron-validator-1.3.1.tgz",
+      "integrity": "sha512-C1HsxuPCY/5opR55G5/WNzyEGDWFVG+6GLrA+fW/sCTcP6A6NTjUP2AK7B8n2PyFs90kDG2qzwm8LMheADku6A=="
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -10986,9 +10992,9 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
     },
     "@nimbella/nimbella-deployer": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.2.1.tgz",
-      "integrity": "sha512-WVeG9f0wD07idaqGm3PQdrMZ5uf9N77bz1amJc6QkmzC6pXtfO1RQfazUH1c6eg/YEp1/fPzAYqV6HdLtCv42g==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.3.1.tgz",
+      "integrity": "sha512-OvDeN9I0ymexk4gtIewYj4wjfVpJh3Y6g3miLQx/Fwvel21wfvGWWRF6fKnANE8VPRdpYMwYIuxM6+JNIKO6KA==",
       "requires": {
         "@aws-sdk/client-s3": "^3.27.0",
         "@nimbella/sdk": "^1.3.5",
@@ -10999,6 +11005,7 @@
         "archiver": "^5.3.0",
         "atob": "^2.1.2",
         "axios": "^0.21.4",
+        "cron-validator": "^1.3.1",
         "debug": "^4.1.1",
         "dotenv": "^16.0.1",
         "ignore": "5.0.6",
@@ -12603,6 +12610,11 @@
         "crc-32": "^1.2.0",
         "readable-stream": "^3.4.0"
       }
+    },
+    "cron-validator": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/cron-validator/-/cron-validator-1.3.1.tgz",
+      "integrity": "sha512-C1HsxuPCY/5opR55G5/WNzyEGDWFVG+6GLrA+fW/sCTcP6A6NTjUP2AK7B8n2PyFs90kDG2qzwm8LMheADku6A=="
     },
     "cross-spawn": {
       "version": "7.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@adobe/aio-cli-plugin-runtime": "github:nimbella/aio-cli-plugin-runtime#v2021-11-19-1",
         "@adobe/aio-lib-core-config": "^2.0.0",
         "@adobe/aio-lib-runtime": "^3.3.0",
-        "@nimbella/nimbella-deployer": "4.3.1",
+        "@nimbella/nimbella-deployer": "4.3.2",
         "@nimbella/storage": "^0.0.7",
         "@oclif/command": "^1",
         "@oclif/config": "^1",
@@ -1755,9 +1755,9 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
     },
     "node_modules/@nimbella/nimbella-deployer": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.3.1.tgz",
-      "integrity": "sha512-OvDeN9I0ymexk4gtIewYj4wjfVpJh3Y6g3miLQx/Fwvel21wfvGWWRF6fKnANE8VPRdpYMwYIuxM6+JNIKO6KA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.3.2.tgz",
+      "integrity": "sha512-GmOUpZxM2IG/Ouq8T79Pfcb9qEbFjSX4gvaZaeFSJrXBmwxDjeXztjot8fxGpafHbxDwQhixknSN4Y/N2QFSRw==",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.27.0",
         "@nimbella/sdk": "^1.3.5",
@@ -10992,9 +10992,9 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
     },
     "@nimbella/nimbella-deployer": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.3.1.tgz",
-      "integrity": "sha512-OvDeN9I0ymexk4gtIewYj4wjfVpJh3Y6g3miLQx/Fwvel21wfvGWWRF6fKnANE8VPRdpYMwYIuxM6+JNIKO6KA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.3.2.tgz",
+      "integrity": "sha512-GmOUpZxM2IG/Ouq8T79Pfcb9qEbFjSX4gvaZaeFSJrXBmwxDjeXztjot8fxGpafHbxDwQhixknSN4Y/N2QFSRw==",
       "requires": {
         "@aws-sdk/client-s3": "^3.27.0",
         "@nimbella/sdk": "^1.3.5",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@adobe/aio-cli-plugin-runtime": "github:nimbella/aio-cli-plugin-runtime#v2021-11-19-1",
     "@adobe/aio-lib-core-config": "^2.0.0",
     "@adobe/aio-lib-runtime": "^3.3.0",
-    "@nimbella/nimbella-deployer": "4.3.1",
+    "@nimbella/nimbella-deployer": "4.3.2",
     "@nimbella/storage": "^0.0.7",
     "@oclif/command": "^1",
     "@oclif/config": "^1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@adobe/aio-cli-plugin-runtime": "github:nimbella/aio-cli-plugin-runtime#v2021-11-19-1",
     "@adobe/aio-lib-core-config": "^2.0.0",
     "@adobe/aio-lib-runtime": "^3.3.0",
-    "@nimbella/nimbella-deployer": "4.2.1",
+    "@nimbella/nimbella-deployer": "4.3.1",
     "@nimbella/storage": "^0.0.7",
     "@oclif/command": "^1",
     "@oclif/config": "^1",


### PR DESCRIPTION
1.  Adopt deployer 4.3.2, which has support for "triggers" in `project.yml` and links triggers to functions via annotations.
2. Use the deployer's `deleteAction` function instead of `aio` when deleting an action.  This allows associated cleanup of the triggers.

The "triggers" being referred to here are not OpenWhisk triggers but rather ones being maintained in another service.