### PR TITLE
Project create now supports typescript in nodejs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@nimbella/nimbella-cli",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nimbella/nimbella-cli",
-      "version": "4.2.2",
+      "version": "4.2.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/aio-cli-plugin-runtime": "github:nimbella/aio-cli-plugin-runtime#v2021-11-19-1",
         "@adobe/aio-lib-core-config": "^2.0.0",
         "@adobe/aio-lib-runtime": "^3.3.0",
-        "@nimbella/nimbella-deployer": "4.3.4",
+        "@nimbella/nimbella-deployer": "4.3.5",
         "@nimbella/storage": "^0.0.7",
         "@oclif/command": "^1",
         "@oclif/config": "^1",
@@ -1751,9 +1751,9 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
     },
     "node_modules/@nimbella/nimbella-deployer": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.3.4.tgz",
-      "integrity": "sha512-uh+oZw4s3LnGTOjIqJQ0JjDjq2oHUSNBmUDlmWnRxIGnq8kMa/V6YDHgrJ5Poc/pPmDS+bon3B2oVjcOns+a6Q==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.3.5.tgz",
+      "integrity": "sha512-jtcf6cg4k0qjf8pSsDtGl6FuAp8fokYiY4PYmJii1bS8SLBYsGb1fY2l++oLddcC4y5oWU8hTwOt2e7TV7fTTg==",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.27.0",
         "@nimbella/sdk": "^1.3.5",
@@ -10952,9 +10952,9 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
     },
     "@nimbella/nimbella-deployer": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.3.4.tgz",
-      "integrity": "sha512-uh+oZw4s3LnGTOjIqJQ0JjDjq2oHUSNBmUDlmWnRxIGnq8kMa/V6YDHgrJ5Poc/pPmDS+bon3B2oVjcOns+a6Q==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.3.5.tgz",
+      "integrity": "sha512-jtcf6cg4k0qjf8pSsDtGl6FuAp8fokYiY4PYmJii1bS8SLBYsGb1fY2l++oLddcC4y5oWU8hTwOt2e7TV7fTTg==",
       "requires": {
         "@aws-sdk/client-s3": "^3.27.0",
         "@nimbella/sdk": "^1.3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/nimbella-cli",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "A comprehensive CLI for the Nimbella stack",
   "main": "lib/index.js",
   "repository": {
@@ -17,7 +17,7 @@
     "@adobe/aio-cli-plugin-runtime": "github:nimbella/aio-cli-plugin-runtime#v2021-11-19-1",
     "@adobe/aio-lib-core-config": "^2.0.0",
     "@adobe/aio-lib-runtime": "^3.3.0",
-    "@nimbella/nimbella-deployer": "4.3.4",
+    "@nimbella/nimbella-deployer": "4.3.5",
     "@nimbella/storage": "^0.0.7",
     "@oclif/command": "^1",
     "@oclif/config": "^1",


### PR DESCRIPTION
This change provides a more realistic way to support typescript in the `nodejs` runtime, rather than assuming there is a 
specialized typescript runtime.

When you specify `nim project create ... --language typescript` the runtime kind is set to `nodejs` but the project is set up with additional material (`package.json`, `tsconfig.json`, `.include`, and `src` and `lib` folders) so that a simple action written in typescript will run.   It should be easy  to generalize this by adding source files, or adding dependencies, modifying generated `.include` accordingly.

Generalizing to multiple actions with shared material should also be easy but will need more validation and may result in some further changes.   The basic structure can be relocated to `lib` and then the multiple source files are organized as needed under `lib/src`.   The entire build runs under `lib` and then the individual actions consist only of `.include` files to tailer what goes into each action.  The individual actions can also have a `package.json` (or not) for establishing the main function.