### PR TITLE
Report trigger deployment success/failure + use updated API to the backend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@nimbella/nimbella-cli",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nimbella/nimbella-cli",
-      "version": "4.2.4",
+      "version": "4.2.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/aio-cli-plugin-runtime": "github:nimbella/aio-cli-plugin-runtime#v2021-11-19-1",
         "@adobe/aio-lib-core-config": "^2.0.0",
         "@adobe/aio-lib-runtime": "^3.3.0",
-        "@nimbella/nimbella-deployer": "4.3.6",
+        "@nimbella/nimbella-deployer": "4.3.7",
         "@nimbella/storage": "^0.0.7",
         "@oclif/command": "^1",
         "@oclif/config": "^1",
@@ -1751,9 +1751,9 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
     },
     "node_modules/@nimbella/nimbella-deployer": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.3.6.tgz",
-      "integrity": "sha512-/cnb3DS3M80FUawzEU0yi6TIRqRUfol/4LHd4APf2526UTxgfl2WRBq27cC+9sNORDBUN21PvB6OgLzwI4n8VQ==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.3.7.tgz",
+      "integrity": "sha512-E1DCRSVx2ofSeetIK3/HaqsTqi3rouI2PBmH8cevDnl7NHjHq4mEbsqLjD0h7bOtcPO1yLh7ZoiQkDB40OIA2w==",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.27.0",
         "@nimbella/sdk": "^1.3.5",
@@ -10952,9 +10952,9 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
     },
     "@nimbella/nimbella-deployer": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.3.6.tgz",
-      "integrity": "sha512-/cnb3DS3M80FUawzEU0yi6TIRqRUfol/4LHd4APf2526UTxgfl2WRBq27cC+9sNORDBUN21PvB6OgLzwI4n8VQ==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.3.7.tgz",
+      "integrity": "sha512-E1DCRSVx2ofSeetIK3/HaqsTqi3rouI2PBmH8cevDnl7NHjHq4mEbsqLjD0h7bOtcPO1yLh7ZoiQkDB40OIA2w==",
       "requires": {
         "@aws-sdk/client-s3": "^3.27.0",
         "@nimbella/sdk": "^1.3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/nimbella-cli",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "description": "A comprehensive CLI for the Nimbella stack",
   "main": "lib/index.js",
   "repository": {
@@ -17,7 +17,7 @@
     "@adobe/aio-cli-plugin-runtime": "github:nimbella/aio-cli-plugin-runtime#v2021-11-19-1",
     "@adobe/aio-lib-core-config": "^2.0.0",
     "@adobe/aio-lib-runtime": "^3.3.0",
-    "@nimbella/nimbella-deployer": "4.3.6",
+    "@nimbella/nimbella-deployer": "4.3.7",
     "@nimbella/storage": "^0.0.7",
     "@oclif/command": "^1",
     "@oclif/config": "^1",

--- a/src/commands/project/deploy.ts
+++ b/src/commands/project/deploy.ts
@@ -212,9 +212,11 @@ function displayResult(result: DeployResponse, watching: boolean, webLocal: stri
   } else {
     logger.log('')
     const actions: string[] = []
+    const triggers: string[] = []
     let deployedWeb = 0
     let skippedActions = 0
     let skippedWeb = 0
+    let skippedTriggers = 0
     for (const success of result.successes) {
       if (success.kind === 'web') {
         if (success.skipped) {
@@ -231,6 +233,12 @@ function displayResult(result: DeployResponse, watching: boolean, webLocal: stri
             name += ` (wrapping ${success.wrapping})`
           }
           actions.push(name)
+        }
+      } else if (success.kind === 'trigger') {
+        if (success.skipped) {
+          skippedTriggers++
+        } else {
+          triggers.push(success.name)
         }
       }
     }
@@ -262,6 +270,15 @@ function displayResult(result: DeployResponse, watching: boolean, webLocal: stri
     }
     if (skippedActions > 0) {
       logger.log(`Skipped ${skippedActions} unchanged actions`)
+    }
+    if (triggers.length > 0) {
+      logger.log('Deployed triggers:')
+      for (const trigger of triggers) {
+        logger.log(`  - ${trigger}`)
+      }
+    }
+    if (skippedTriggers > 0) {
+      logger.log(`Skipped ${skippedTriggers} triggers`)
     }
     if (result.failures.length > 0) {
       success = false


### PR DESCRIPTION
Since version 4.2.0 `nim` had offered support for triggers (via the deployer).   These are not OpenWhisk triggers but triggers implemented by DIgitalOcean external to the OpenWhisk cluster.

This change  moves trigger support closer to the point where it will be ready to be released to the public.   The change does two things
1.  It changes the logic in `nim` proper so that trigger deployment successes and failures are reported independently of action (function) successes and failures.   Although triggers are tied to functions, their deployment is separable and can fail even when the function deployment succeeds. 
2. It brings in the latest deployer version in which contact to the backend goes via an API that is closer to what will eventually be supported.

