### PR TITLE
Ensure more orderly deletion of triggers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@nimbella/nimbella-cli",
-  "version": "4.2.6",
+  "version": "4.2.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nimbella/nimbella-cli",
-      "version": "4.2.6",
+      "version": "4.2.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/aio-cli-plugin-runtime": "github:nimbella/aio-cli-plugin-runtime#v2021-11-19-1",
         "@adobe/aio-lib-core-config": "^2.0.0",
         "@adobe/aio-lib-runtime": "^3.3.0",
-        "@nimbella/nimbella-deployer": "4.3.8",
+        "@nimbella/nimbella-deployer": "4.3.9",
         "@nimbella/storage": "^0.0.7",
         "@oclif/command": "^1",
         "@oclif/config": "^1",
@@ -1751,9 +1751,9 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
     },
     "node_modules/@nimbella/nimbella-deployer": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.3.8.tgz",
-      "integrity": "sha512-cGuYqogsp1XCqbrih1zVv9KSdS/fpmX5e74hmuL02HtCZOQGF/ApyuQzj4A4uR6IJhYZE/75olVN6bQpCKKfKg==",
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.3.9.tgz",
+      "integrity": "sha512-zcTIyJuwpy8J9KORqUThtH3SKuuaIWP8BbRQys3QbTc6pNo99nq94QRZ4WoTs5KfbsBXIxP9LqLpliQ0v0JuwA==",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.27.0",
         "@nimbella/sdk": "^1.3.5",
@@ -10952,9 +10952,9 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
     },
     "@nimbella/nimbella-deployer": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.3.8.tgz",
-      "integrity": "sha512-cGuYqogsp1XCqbrih1zVv9KSdS/fpmX5e74hmuL02HtCZOQGF/ApyuQzj4A4uR6IJhYZE/75olVN6bQpCKKfKg==",
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.3.9.tgz",
+      "integrity": "sha512-zcTIyJuwpy8J9KORqUThtH3SKuuaIWP8BbRQys3QbTc6pNo99nq94QRZ4WoTs5KfbsBXIxP9LqLpliQ0v0JuwA==",
       "requires": {
         "@aws-sdk/client-s3": "^3.27.0",
         "@nimbella/sdk": "^1.3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/nimbella-cli",
-  "version": "4.2.6",
+  "version": "4.2.7",
   "description": "A comprehensive CLI for the Nimbella stack",
   "main": "lib/index.js",
   "repository": {
@@ -17,7 +17,7 @@
     "@adobe/aio-cli-plugin-runtime": "github:nimbella/aio-cli-plugin-runtime#v2021-11-19-1",
     "@adobe/aio-lib-core-config": "^2.0.0",
     "@adobe/aio-lib-runtime": "^3.3.0",
-    "@nimbella/nimbella-deployer": "4.3.8",
+    "@nimbella/nimbella-deployer": "4.3.9",
     "@nimbella/storage": "^0.0.7",
     "@oclif/command": "^1",
     "@oclif/config": "^1",


### PR DESCRIPTION
Incorporates deployer 4.3.9, declares version 4.2.7.

See https://github.com/nimbella/nimbella-deployer/releases/tag/v4.3.9.

Also changes `action delete` to respond more appropriately to the new-style error returns from the deployer's `deleteAction` function.