### PR TITLE
Fail silently when listing triggers if not authorized

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@nimbella/nimbella-cli",
-  "version": "4.2.7",
+  "version": "4.2.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nimbella/nimbella-cli",
-      "version": "4.2.7",
+      "version": "4.2.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/aio-cli-plugin-runtime": "github:nimbella/aio-cli-plugin-runtime#v2021-11-19-1",
         "@adobe/aio-lib-core-config": "^2.0.0",
         "@adobe/aio-lib-runtime": "^3.3.0",
-        "@nimbella/nimbella-deployer": "4.3.9",
+        "@nimbella/nimbella-deployer": "4.3.10",
         "@nimbella/storage": "^0.0.7",
         "@oclif/command": "^1",
         "@oclif/config": "^1",
@@ -1751,9 +1751,9 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
     },
     "node_modules/@nimbella/nimbella-deployer": {
-      "version": "4.3.9",
-      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.3.9.tgz",
-      "integrity": "sha512-zcTIyJuwpy8J9KORqUThtH3SKuuaIWP8BbRQys3QbTc6pNo99nq94QRZ4WoTs5KfbsBXIxP9LqLpliQ0v0JuwA==",
+      "version": "4.3.10",
+      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.3.10.tgz",
+      "integrity": "sha512-Uf5OaVB5Xw+wDrmnKk8TaTz8mMzidnEIpnn4Vcill0c58+GHwP+4UUNt5D/JhzWh7XptVtAISkp/qOWtIQCFZQ==",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.27.0",
         "@nimbella/sdk": "^1.3.5",
@@ -10952,9 +10952,9 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
     },
     "@nimbella/nimbella-deployer": {
-      "version": "4.3.9",
-      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.3.9.tgz",
-      "integrity": "sha512-zcTIyJuwpy8J9KORqUThtH3SKuuaIWP8BbRQys3QbTc6pNo99nq94QRZ4WoTs5KfbsBXIxP9LqLpliQ0v0JuwA==",
+      "version": "4.3.10",
+      "resolved": "https://registry.npmjs.org/@nimbella/nimbella-deployer/-/nimbella-deployer-4.3.10.tgz",
+      "integrity": "sha512-Uf5OaVB5Xw+wDrmnKk8TaTz8mMzidnEIpnn4Vcill0c58+GHwP+4UUNt5D/JhzWh7XptVtAISkp/qOWtIQCFZQ==",
       "requires": {
         "@aws-sdk/client-s3": "^3.27.0",
         "@nimbella/sdk": "^1.3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/nimbella-cli",
-  "version": "4.2.7",
+  "version": "4.2.8",
   "description": "A comprehensive CLI for the Nimbella stack",
   "main": "lib/index.js",
   "repository": {
@@ -17,7 +17,7 @@
     "@adobe/aio-cli-plugin-runtime": "github:nimbella/aio-cli-plugin-runtime#v2021-11-19-1",
     "@adobe/aio-lib-core-config": "^2.0.0",
     "@adobe/aio-lib-runtime": "^3.3.0",
-    "@nimbella/nimbella-deployer": "4.3.9",
+    "@nimbella/nimbella-deployer": "4.3.10",
     "@nimbella/storage": "^0.0.7",
     "@oclif/command": "^1",
     "@oclif/config": "^1",


### PR DESCRIPTION
This change incorporates a fix to the deployer in version 4.3.10.  When the attempt is made to list triggers during a "wipe" operation (namespace or package) or when deleting a function, the attempt is allowed to fail silently.  Some users may not be authorized to the triggers API and so will not have any triggers.   If the API fails, the empty list is returned.